### PR TITLE
Fix showcase tutorial initialization

### DIFF
--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -84,7 +84,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     'assets/images/voice_listen3.webp',
   ];
 
-  final GlobalKey<ShowCaseWidgetState> _showCaseKey = GlobalKey();
   final GlobalKey _registerSpeakerKey = GlobalKey();
   final GlobalKey _identifySpeakerKey = GlobalKey();
   final GlobalKey _speakerBookKey = GlobalKey();
@@ -366,7 +365,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       setState(() => _showTutorial = true);
       Future.delayed(const Duration(milliseconds: 900), () {
         if (mounted) {
-          _showCaseKey.currentState?.startShowCase([
+          ShowCaseWidget.of(context).startShowCase([
             _registerSpeakerKey,
             _identifySpeakerKey,
             _speakerBookKey,


### PR DESCRIPTION
## Summary
- ensure the tutorial is started using `ShowCaseWidget.of(context)`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687922535aec83319de9a60e693f9a2f