### PR TITLE
Improve AddContactScreen mic guidance

### DIFF
--- a/lib/feature/auth/presentation/views/add_contact_screen.dart
+++ b/lib/feature/auth/presentation/views/add_contact_screen.dart
@@ -58,6 +58,7 @@ class _AddContactScreenState extends State<AddContactScreen>
   bool _userStartedSpeaking = false;
   DateTime? _lastVoiceTime;
   bool _dialogActive = false;
+  bool _showMicTutorial = false;
 
   static const int silenceThresholdMs = 700;
   static const int ignoreInitialMs = 300;
@@ -68,6 +69,7 @@ class _AddContactScreenState extends State<AddContactScreen>
     super.initState();
     _nameController = TextEditingController(text: widget.name);
     _loadStoredEmail();
+    _checkFirstTime();
     WidgetsBinding.instance.addPostFrameCallback((_) => _askForContactName());
 
     _micPulse = AnimationController(
@@ -98,6 +100,15 @@ class _AddContactScreenState extends State<AddContactScreen>
     setState(() {
       _email = prefs.getString('email') ?? '';
     });
+  }
+
+  Future<void> _checkFirstTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    final shown = prefs.getBool('add_contact_tutorial_shown') ?? false;
+    if (!shown && mounted) {
+      setState(() => _showMicTutorial = true);
+      await prefs.setBool('add_contact_tutorial_shown', true);
+    }
   }
 
   void _revealWords() {
@@ -486,6 +497,66 @@ class _AddContactScreenState extends State<AddContactScreen>
     }
   }
 
+  Widget _buildTutorialOverlay(BuildContext context, Size size) {
+    return Positioned.fill(
+      child: Container(
+        color: Colors.black87.withOpacity(0.7),
+        child: Stack(
+          children: [
+            Align(
+              alignment: Alignment.topRight,
+              child: IconButton(
+                icon: const Icon(Icons.close, color: Colors.white),
+                onPressed: () => setState(() => _showMicTutorial = false),
+              ),
+            ),
+            Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 110,
+                    height: 110,
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.white24,
+                    ),
+                    child: const Icon(Icons.mic, color: Colors.white, size: 60),
+                  ),
+                  const SizedBox(height: 20),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                    child: Text(
+                      context.loc.tapMicToStart,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                    child: Text(
+                      context.loc.tapMicToRecord,
+                      style: TextStyle(
+                        color: Colors.white.withOpacity(0.9),
+                        fontSize: 16,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final words = _sentences[_currentIndex].split(' ');
@@ -543,8 +614,10 @@ class _AddContactScreenState extends State<AddContactScreen>
             stops: const [0.1, 0.7, 1.0],
           ),
         ),
-        child: SafeArea(
-          child: Column(
+        child: Stack(
+          children: [
+            SafeArea(
+              child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               const SizedBox(height: 16),
@@ -758,7 +831,10 @@ class _AddContactScreenState extends State<AddContactScreen>
                   child: CircularProgressIndicator(color: Colors.purpleAccent),
                 ),
             ],
-          ),
+              ),
+            ),
+            if (_showMicTutorial) _buildTutorialOverlay(context, size),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add a stored preference check for displaying a tutorial
- show a tutorial overlay with microphone instructions on first launch

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a28d4d2b08331a4a8ff564d9d642f