### PR TITLE
Enhance SpeakerScreen onboarding

### DIFF
--- a/lib/feature/auth/presentation/views/add_contact_screen.dart
+++ b/lib/feature/auth/presentation/views/add_contact_screen.dart
@@ -58,6 +58,10 @@ class _AddContactScreenState extends State<AddContactScreen>
   bool _userStartedSpeaking = false;
   DateTime? _lastVoiceTime;
   bool _dialogActive = false;
+  bool _showMicTutorial = false;
+  bool _showRepeatTutorial = false;
+  bool _repeatTutorialSeen = false;
+  bool _showNameIntro = false;
 
   static const int silenceThresholdMs = 700;
   static const int ignoreInitialMs = 300;
@@ -68,6 +72,7 @@ class _AddContactScreenState extends State<AddContactScreen>
     super.initState();
     _nameController = TextEditingController(text: widget.name);
     _loadStoredEmail();
+    _loadTutorialFlags();
     WidgetsBinding.instance.addPostFrameCallback((_) => _askForContactName());
 
     _micPulse = AnimationController(
@@ -98,6 +103,21 @@ class _AddContactScreenState extends State<AddContactScreen>
     setState(() {
       _email = prefs.getString('email') ?? '';
     });
+  }
+
+  Future<void> _loadTutorialFlags() async {
+    final prefs = await SharedPreferences.getInstance();
+    final micShown = prefs.getBool('add_contact_mic_tutorial_shown') ?? false;
+    final repeatShown = prefs.getBool('add_contact_repeat_tutorial_shown') ?? false;
+    final nameShown = prefs.getBool('add_contact_name_intro_shown') ?? false;
+    if (mounted) {
+      setState(() {
+        _showMicTutorial = !micShown;
+        _repeatTutorialSeen = repeatShown;
+        _showNameIntro = !nameShown;
+      });
+    }
+    if (!micShown) await prefs.setBool('add_contact_mic_tutorial_shown', true);
   }
 
   void _revealWords() {
@@ -219,6 +239,7 @@ class _AddContactScreenState extends State<AddContactScreen>
   Future<void> _askForContactName() async {
     _dialogActive = true;
     final isDark = widget.isDarkMode;
+    final prefs = await SharedPreferences.getInstance();
 
     final enteredName = await showDialog<String>(
       context: context,
@@ -309,6 +330,19 @@ class _AddContactScreenState extends State<AddContactScreen>
                         ),
                         textAlign: TextAlign.center,
                       ),
+                      if (_showNameIntro)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 12.0),
+                          child: Text(
+                            context.loc.nameFieldIntro,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: isDark ? Colors.white70 : Colors.black87,
+                              fontSize: 13,
+                              fontStyle: FontStyle.italic,
+                            ),
+                          ),
+                        ),
                       const SizedBox(height: 16),
 
                       // Name TextField (no labelText)
@@ -386,6 +420,11 @@ class _AddContactScreenState extends State<AddContactScreen>
     );
 
     _dialogActive = false;
+
+    if (_showNameIntro) {
+      await prefs.setBool('add_contact_name_intro_shown', true);
+      if (mounted) setState(() => _showNameIntro = false);
+    }
 
     if (enteredName == null || enteredName.trim().isEmpty) {
       _nameController?.dispose();
@@ -479,11 +518,103 @@ class _AddContactScreenState extends State<AddContactScreen>
   }
 
   void _onMicTap() {
+    if (!_repeatTutorialSeen) {
+      setState(() => _showRepeatTutorial = true);
+      _repeatTutorialSeen = true;
+      SharedPreferences.getInstance().then((p) => p.setBool('add_contact_repeat_tutorial_shown', true));
+      return;
+    }
     if (_isRecording) {
       _stopRecording();
     } else {
       _startRecording();
     }
+  }
+
+  Widget _buildTutorialOverlay(BuildContext context) {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _showMicTutorial = false),
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 110,
+                  height: 110,
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.white24,
+                  ),
+                  child: const Icon(Icons.mic, color: Colors.white, size: 60),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                  child: Text(
+                    context.loc.tapMicToStart,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                  child: Text(
+                    context.loc.tapMicToRecord,
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.9),
+                      fontSize: 16,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRepeatTutorialOverlay(BuildContext context) {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _showRepeatTutorial = false),
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.record_voice_over, color: Colors.white, size: 60),
+                const SizedBox(height: 16),
+                Text(
+                  context.loc.repeatSentenceHint,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  context.loc.tapMicToRecord,
+                  style: TextStyle(color: Colors.white.withOpacity(0.9), fontSize: 15),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   @override
@@ -543,8 +674,10 @@ class _AddContactScreenState extends State<AddContactScreen>
             stops: const [0.1, 0.7, 1.0],
           ),
         ),
-        child: SafeArea(
-          child: Column(
+        child: Stack(
+          children: [
+            SafeArea(
+              child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               const SizedBox(height: 16),
@@ -758,7 +891,11 @@ class _AddContactScreenState extends State<AddContactScreen>
                   child: CircularProgressIndicator(color: Colors.purpleAccent),
                 ),
             ],
-          ),
+              ),
+            ),
+            if (_showRepeatTutorial) _buildRepeatTutorialOverlay(context),
+            if (_showMicTutorial) _buildTutorialOverlay(context),
+          ],
         ),
       ),
     );

--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -29,6 +29,7 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
   List<Speaker> _speakers = [];
   String _email = '';
   String _loginType = '';
+  bool _showIntro = false;
 
   late final AnimationController _listAnimController;
 
@@ -170,7 +171,9 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
     setState(() {
       _email = prefs.getString('email') ?? '';
       _loginType = prefs.getString('login_type') ?? '';
+      _showIntro = !(prefs.getBool('speaker_intro_shown') ?? false);
     });
+    if (_showIntro) await prefs.setBool('speaker_intro_shown', true);
     await _fetchSpeakers();
   }
 
@@ -478,30 +481,32 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
             stops: const [0.1, 0.7, 1.0],
           ),
         ),
-        child: SafeArea(
-          child: _loading
+        child: Stack(
+          children: [
+            SafeArea(
+              child: _loading
               ? const Center(child: CircularProgressIndicator(color: Colors.cyanAccent))
               : _error != null
               ? Center(
-            child: Text(
-              _error!,
-              style: const TextStyle(color: Colors.redAccent, fontSize: 16),
-            ),
-          )
+                child: Text(
+                  _error!,
+                  style: const TextStyle(color: Colors.redAccent, fontSize: 16),
+                ),
+              )
               : RefreshIndicator(
-            onRefresh: _fetchSpeakers,
-            color: widget.isDarkMode ? Colors.cyanAccent : Colors.deepPurpleAccent,
-            backgroundColor: widget.isDarkMode ? Colors.grey[900]! : Colors.white,
-            edgeOffset: 20,
-            child: _speakers.isEmpty
-                ? _NoSpeakersWidget(
-              isDarkMode: widget.isDarkMode,
-              phoneNumber: widget.phoneNumber,
-            )
-                : ListView.builder(
-              physics: const AlwaysScrollableScrollPhysics(),
-              padding: const EdgeInsets.only(top: 12, left: 18, right: 18, bottom: 40),
-              itemCount: _speakers.length,
+                onRefresh: _fetchSpeakers,
+                color: widget.isDarkMode ? Colors.cyanAccent : Colors.deepPurpleAccent,
+                backgroundColor: widget.isDarkMode ? Colors.grey[900]! : Colors.white,
+                edgeOffset: 20,
+                child: _speakers.isEmpty
+                    ? _NoSpeakersWidget(
+                        isDarkMode: widget.isDarkMode,
+                        phoneNumber: widget.phoneNumber,
+                      )
+                    : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.only(top: 12, left: 18, right: 18, bottom: 40),
+                        itemCount: _speakers.length,
               itemBuilder: (_, i) {
                 final s = _speakers[i];
                 final avatarColors = _avatarGradients[i % _avatarGradients.length];
@@ -684,6 +689,49 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                   ),
                 );
               },
+            ),
+          ),
+            ),
+            if (_showIntro) _buildIntroOverlay(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIntroOverlay(BuildContext context) {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _showIntro = false),
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.person_search, color: Colors.white, size: 64),
+                const SizedBox(height: 20),
+                Text(
+                  context.loc.speakerListIntro,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  context.loc.speakerAddIntro,
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.9),
+                    fontSize: 15,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -84,5 +84,9 @@
   "feMale":"মহিলা",
   "other":"অন্যান্য",
   "trialExpired":"বিচারের মেয়াদ শেষ",
-  "hindi": "হিন্দি"
+  "hindi": "হিন্দি",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -84,5 +84,9 @@
   "feMale":"Female",
   "other":"Other",
   "trialExpired":"Trial Expired",
-  "hindi":"Hindi"
+  "hindi":"Hindi",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -84,5 +84,9 @@
   "feMale":"સ્ત્રી",
   "other":"અન્ય",
   "trialExpired":"ટ્રાયલ સમાપ્ત",
-  "hindi": "હિન્દી"
-}
+  "hindi": "હિન્દી",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -84,6 +84,10 @@
   "feMale":"महिला",
   "other":"अन्य",
   "trialExpired":"परीक्षण समाप्त",
-  "hindi":"हिंदी"
-}
+  "hindi":"हिंदी",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }
 

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -84,5 +84,9 @@
   "feMale":"स्त्री",
   "other":"इतर",
   "hindi": "हिंदी",
-  "trialExpired":"चाचणी कालबाह्य झाली"
-}
+  "trialExpired":"चाचणी कालबाह्य झाली",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -84,5 +84,9 @@
   "feMale":"ਔਰਤ",
   "other":"ਹੋਰ",
   "hindi": "ਹਿੰਦੀ",
-  "trialExpired":"ਮੁਕੱਦਮੇ ਦੀ ਮਿਆਦ ਪੁੱਗ ਗਈ"
-}
+  "trialExpired":"ਮੁਕੱਦਮੇ ਦੀ ਮਿਆਦ ਪੁੱਗ ਗਈ",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -84,5 +84,9 @@
   "feMale":"பெண்",
   "other":"மற்றவை",
   "hindi": "இந்தி",
-  "trialExpired":"சோதனை காலாவதியானது"
-}
+  "trialExpired":"சோதனை காலாவதியானது",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -84,5 +84,9 @@
   "feMale":"خاتون",
   "other":"دیگر",
   "hindi": "ہندی",
-  "trialExpired":"مقدمے کی مدت ختم ہو گئی۔"
-}
+  "trialExpired":"مقدمے کی مدت ختم ہو گئی۔",
+  "nameFieldIntro":"This is your friend's name.",
+  "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
+  "speakerListIntro":"This screen lists your registered speakers.",
+  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+ }


### PR DESCRIPTION
## Summary
- show one-time mic tutorial overlay in AddContactScreen
- add persistent intro overlay in SpeakerScreen
- include localization keys for the intro overlay across all languages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a28d4d2b08331a4a8ff564d9d642f