### PR TITLE
Improve user onboarding with new intros

### DIFF
--- a/lib/feature/auth/presentation/views/add_contact_screen.dart
+++ b/lib/feature/auth/presentation/views/add_contact_screen.dart
@@ -73,7 +73,6 @@ class _AddContactScreenState extends State<AddContactScreen>
     _nameController = TextEditingController(text: widget.name);
     _loadStoredEmail();
     _loadTutorialFlags();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _askForContactName());
 
     _micPulse = AnimationController(
       vsync: this,
@@ -118,6 +117,12 @@ class _AddContactScreenState extends State<AddContactScreen>
       });
     }
     if (!micShown) await prefs.setBool('add_contact_mic_tutorial_shown', true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (nameShown) {
+        _askForContactName();
+      }
+    });
   }
 
   void _revealWords() {
@@ -330,19 +335,7 @@ class _AddContactScreenState extends State<AddContactScreen>
                         ),
                         textAlign: TextAlign.center,
                       ),
-                      if (_showNameIntro)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 12.0),
-                          child: Text(
-                            context.loc.nameFieldIntro,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: isDark ? Colors.white70 : Colors.black87,
-                              fontSize: 13,
-                              fontStyle: FontStyle.italic,
-                            ),
-                          ),
-                        ),
+
                       const SizedBox(height: 16),
 
                       // Name TextField (no labelText)
@@ -420,11 +413,6 @@ class _AddContactScreenState extends State<AddContactScreen>
     );
 
     _dialogActive = false;
-
-    if (_showNameIntro) {
-      await prefs.setBool('add_contact_name_intro_shown', true);
-      if (mounted) setState(() => _showNameIntro = false);
-    }
 
     if (enteredName == null || enteredName.trim().isEmpty) {
       _nameController?.dispose();
@@ -607,6 +595,54 @@ class _AddContactScreenState extends State<AddContactScreen>
                 Text(
                   context.loc.tapMicToRecord,
                   style: TextStyle(color: Colors.white.withOpacity(0.9), fontSize: 15),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _hideNameIntro() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('add_contact_name_intro_shown', true);
+    if (!mounted) return;
+    setState(() => _showNameIntro = false);
+    _askForContactName();
+  }
+
+  Widget _buildNameIntroOverlay(BuildContext context) {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _hideNameIntro,
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.person, color: Colors.white, size: 64),
+                const SizedBox(height: 20),
+                Text(
+                  context.loc.enterAFriendlyName,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  context.loc.nameFieldIntro,
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.9),
+                    fontSize: 15,
+                  ),
                   textAlign: TextAlign.center,
                 ),
               ],
@@ -893,6 +929,7 @@ class _AddContactScreenState extends State<AddContactScreen>
                 ],
               ),
             ),
+            if (_showNameIntro) _buildNameIntroOverlay(context),
             if (_showRepeatTutorial) _buildRepeatTutorialOverlay(context),
             if (_showMicTutorial) _buildTutorialOverlay(context),
           ],

--- a/lib/feature/auth/presentation/views/friend_book.dart
+++ b/lib/feature/auth/presentation/views/friend_book.dart
@@ -29,6 +29,7 @@ class _FriendBookScreenState extends State<FriendBookScreen>
   String? _error;
   List<String> _friendEmails = [];
   String _email = '';
+  bool _showIntro = false;
 
   late final AnimationController _listAnimController;
 
@@ -50,6 +51,7 @@ class _FriendBookScreenState extends State<FriendBookScreen>
       duration: Duration(milliseconds: 950),
     );
     _loadMode();
+    _loadIntro();
     _loadEmailAndFetch();
   }
 
@@ -63,6 +65,13 @@ class _FriendBookScreenState extends State<FriendBookScreen>
     setState(() {
       _isDarkMode = prefs.getBool('darkMode') ?? false;
     });
+  }
+
+  Future<void> _loadIntro() async {
+    final prefs = await SharedPreferences.getInstance();
+    final shown = prefs.getBool('friend_book_intro_shown') ?? false;
+    if (mounted) setState(() => _showIntro = !shown);
+    if (!shown) await prefs.setBool('friend_book_intro_shown', true);
   }
   Future<void> _loadEmailAndFetch() async {
     final prefs = await SharedPreferences.getInstance();
@@ -250,6 +259,46 @@ class _FriendBookScreenState extends State<FriendBookScreen>
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildIntroOverlay() {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _showIntro = false),
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.group, color: Colors.white, size: 64),
+                const SizedBox(height: 20),
+                Text(
+                  context.loc.friendBookIntro,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  context.loc.friendChatIntro,
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.9),
+                    fontSize: 15,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -461,16 +510,18 @@ class _FriendBookScreenState extends State<FriendBookScreen>
           ),
         ),
       ),
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: gradientColors,
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            stops: const [0.1, 0.7, 1.0],
-          ),
-        ),
-        child: SafeArea(
+      body: Stack(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: gradientColors,
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                stops: const [0.1, 0.7, 1.0],
+              ),
+            ),
+            child: SafeArea(
           child: _loading
               ? const Center(
             child: CircularProgressIndicator(color: Colors.cyanAccent),
@@ -673,6 +724,8 @@ class _FriendBookScreenState extends State<FriendBookScreen>
             ),
           ),
         ),
+          if (_showIntro) _buildIntroOverlay(context),
+        ],
       ),
     );
   }

--- a/lib/feature/auth/presentation/views/friend_list_screen.dart
+++ b/lib/feature/auth/presentation/views/friend_list_screen.dart
@@ -28,6 +28,7 @@ class _FriendListScreenState extends State<FriendListScreen>
   String? _error;
   List<User> _users = [];
   String _email = '';
+  bool _showIntro = false;
 
   final List<List<Color>> _avatarGradients = [
     [Color(0xFF8EC5FC), Color(0xFFE0C3FC)],
@@ -47,6 +48,7 @@ class _FriendListScreenState extends State<FriendListScreen>
       vsync: this,
       duration: Duration(milliseconds: 950),
     );
+    _loadIntro();
     _loadEmailAndFetch();
   }
 
@@ -54,6 +56,13 @@ class _FriendListScreenState extends State<FriendListScreen>
   void dispose() {
     _listAnimController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadIntro() async {
+    final prefs = await SharedPreferences.getInstance();
+    final shown = prefs.getBool('friend_list_intro_shown') ?? false;
+    if (mounted) setState(() => _showIntro = !shown);
+    if (!shown) await prefs.setBool('friend_list_intro_shown', true);
   }
 
   Future<void> _loadEmailAndFetch() async {
@@ -304,6 +313,46 @@ class _FriendListScreenState extends State<FriendListScreen>
     );
   }
 
+  Widget _buildIntroOverlay() {
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _showIntro = false),
+        child: Container(
+          color: Colors.black87.withOpacity(0.7),
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.person_add_alt_1, color: Colors.white, size: 64),
+                const SizedBox(height: 20),
+                Text(
+                  context.loc.friendListIntro,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  context.loc.friendAddIntro,
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.9),
+                    fontSize: 15,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final gradientColors = widget.isDarkMode
@@ -371,21 +420,23 @@ class _FriendListScreenState extends State<FriendListScreen>
           ),
         ),
       ),
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: gradientColors,
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            stops: const [0.1, 0.7, 1.0],
-          ),
-        ),
-        child: SafeArea(
-          child: _loading
-              ? const Center(
-            child: CircularProgressIndicator(color: Colors.cyanAccent),
-          )
-              : _error != null
+      body: Stack(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: gradientColors,
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                stops: const [0.1, 0.7, 1.0],
+              ),
+            ),
+            child: SafeArea(
+              child: _loading
+                  ? const Center(
+                child: CircularProgressIndicator(color: Colors.cyanAccent),
+              )
+                  : _error != null
               ? Center (
             child: Text(
               _error!,
@@ -524,8 +575,10 @@ class _FriendListScreenState extends State<FriendListScreen>
                 );
               },
             ),
+            ),
           ),
-        ),
+          if (_showIntro) _buildIntroOverlay(context),
+        ],
       ),
     );
   }
@@ -768,6 +821,7 @@ class _InfoChip extends StatelessWidget {
     );
   }
 }
+
 
 class _NoUsersWidget extends StatelessWidget {
   final bool isDarkMode;

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -85,8 +85,12 @@
   "other":"অন্যান্য",
   "trialExpired":"বিচারের মেয়াদ শেষ",
   "hindi": "হিন্দি",
-  "nameFieldIntro":"এটা তোমার বন্ধুর নাম।",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"সমস্ত প্রশ্ন সম্পূর্ণ করতে প্রদর্শিত বাক্যটি পুনরাবৃত্তি করুন।",
   "speakerListIntro":"এই স্ক্রিনে আপনার নিবন্ধিত স্পিকারগুলির তালিকা রয়েছে।",
-  "speakerAddIntro":"নতুন ভয়েস নিবন্ধন করতে স্পিকার যোগ করুন-এ ট্যাপ করুন।"
+  "speakerAddIntro":"নতুন ভয়েস নিবন্ধন করতে স্পিকার যোগ করুন-এ ট্যাপ করুন।",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -85,8 +85,12 @@
   "other":"Other",
   "trialExpired":"Trial Expired",
   "hindi":"Hindi",
-  "nameFieldIntro":"This is your friend's name.",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"Repeat the displayed sentence to complete all questions.",
   "speakerListIntro":"This screen lists your registered speakers.",
-  "speakerAddIntro":"Tap Add Speaker to register a new voice."
+  "speakerAddIntro":"Tap Add Speaker to register a new voice.",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -85,8 +85,12 @@
   "other":"અન્ય",
   "trialExpired":"ટ્રાયલ સમાપ્ત",
   "hindi": "હિન્દી",
-  "nameFieldIntro":"આ તમારા મિત્રનું નામ છે.",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"બધા પ્રશ્નો પૂર્ણ કરવા માટે પ્રદર્શિત વાક્યનું પુનરાવર્તન કરો.",
   "speakerListIntro":"આ સ્ક્રીન તમારા નોંધાયેલા સ્પીકર્સની યાદી આપે છે.",
-  "speakerAddIntro":"નવો અવાજ નોંધાવવા માટે સ્પીકર ઉમેરો પર ટેપ કરો."
+  "speakerAddIntro":"નવો અવાજ નોંધાવવા માટે સ્પીકર ઉમેરો પર ટેપ કરો.",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -86,8 +86,12 @@
   "other":"अन्य",
   "trialExpired":"परीक्षण समाप्त",
   "hindi":"हिंदी",
-  "nameFieldIntro":"આ તમારા મિત્રનું નામ છે.",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"બધા પ્રશ્નો પૂર્ણ કરવા માટે પ્રદર્શિત વાક્યનું પુનરાવર્તન કરો.",
   "speakerListIntro":"આ સ્ક્રીન તમારા નોંધાયેલા સ્પીકર્સની યાદી આપે છે.",
-  "speakerAddIntro":"નવો અવાજ નોંધાવવા માટે સ્પીકર ઉમેરો પર ટેપ કરો."
+  "speakerAddIntro":"નવો અવાજ નોંધાવવા માટે સ્પીકર ઉમેરો પર ટેપ કરો.",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -85,8 +85,12 @@
   "other":"इतर",
   "hindi": "हिंदी",
   "trialExpired":"चाचणी कालबाह्य झाली",
-  "nameFieldIntro":"हे तुमच्या मित्राचे नाव आहे.",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"सर्व प्रश्न पूर्ण करण्यासाठी प्रदर्शित वाक्याची पुनरावृत्ती करा.",
   "speakerListIntro":"या स्क्रीनवर तुमचे नोंदणीकृत स्पीकर्स सूचीबद्ध आहेत.",
-  "speakerAddIntro":"नवीन आवाज नोंदणी करण्यासाठी स्पीकर जोडा वर टॅप करा."
+  "speakerAddIntro":"नवीन आवाज नोंदणी करण्यासाठी स्पीकर जोडा वर टॅप करा.",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -85,8 +85,12 @@
   "other":"ਹੋਰ",
   "hindi": "ਹਿੰਦੀ",
   "trialExpired":"ਮੁਕੱਦਮੇ ਦੀ ਮਿਆਦ ਪੁੱਗ ਗਈ",
-  "nameFieldIntro":"ਇਹ ਤੁਹਾਡੇ ਦੋਸਤ ਦਾ ਨਾਮ ਹੈ।",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"ਸਾਰੇ ਸਵਾਲ ਪੂਰੇ ਕਰਨ ਲਈ ਪ੍ਰਦਰਸ਼ਿਤ ਵਾਕ ਨੂੰ ਦੁਹਰਾਓ।",
   "speakerListIntro":"ਇਹ ਸਕ੍ਰੀਨ ਤੁਹਾਡੇ ਰਜਿਸਟਰਡ ਸਪੀਕਰਾਂ ਨੂੰ ਸੂਚੀਬੱਧ ਕਰਦੀ ਹੈ।",
-  "speakerAddIntro":"ਨਵੀਂ ਆਵਾਜ਼ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਸਪੀਕਰ ਜੋੜੋ 'ਤੇ ਟੈਪ ਕਰੋ।"
+  "speakerAddIntro":"ਨਵੀਂ ਆਵਾਜ਼ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਸਪੀਕਰ ਜੋੜੋ 'ਤੇ ਟੈਪ ਕਰੋ।",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -85,8 +85,12 @@
   "other":"மற்றவை",
   "hindi": "இந்தி",
   "trialExpired":"சோதனை காலாவதியானது",
-  "nameFieldIntro":"இது உங்க ஃப்ரெண்ட் பேரு.",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"அனைத்து கேள்விகளையும் முடிக்க காட்டப்படும் வாக்கியத்தை மீண்டும் செய்யவும்.",
   "speakerListIntro":"இந்தத் திரை உங்கள் பதிவுசெய்யப்பட்ட பேச்சாளர்களைப் பட்டியலிடுகிறது.",
-  "speakerAddIntro":"புதிய குரலைப் பதிவு செய்ய, பேச்சாளரைச் சேர் என்பதைத் தட்டவும்."
+  "speakerAddIntro":"புதிய குரலைப் பதிவு செய்ய, பேச்சாளரைச் சேர் என்பதைத் தட்டவும்.",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -85,8 +85,12 @@
   "other":"دیگر",
   "hindi": "ہندی",
   "trialExpired":"مقدمے کی مدت ختم ہو گئی۔",
-  "nameFieldIntro":"یہ آپ کے دوست کا نام ہے۔",
+  "nameFieldIntro":"Add the speaker's name to easily recognize their voice.",
   "repeatSentenceHint":"تمام سوالات کو مکمل کرنے کے لیے دکھائے گئے جملے کو دہرائیں۔",
   "speakerListIntro":"یہ اسکرین آپ کے رجسٹرڈ اسپیکرز کی فہرست بناتی ہے۔",
-  "speakerAddIntro":"نئی آواز رجسٹر کرنے کے لیے اسپیکر شامل کریں پر ٹیپ کریں۔"
+  "speakerAddIntro":"نئی آواز رجسٹر کرنے کے لیے اسپیکر شامل کریں پر ٹیپ کریں۔",
+  "friendListIntro":"Browse people and send them a friend request.",
+  "friendAddIntro":"Tap the add icon to connect and start chatting.",
+  "friendBookIntro":"Your approved friends appear here.",
+  "friendChatIntro":"Tap the chat bubble to start a conversation."
 }


### PR DESCRIPTION
## Summary
- add first-time intro overlay on Friend List and Friend Book screens
- guide users about entering speaker names in Add Contact screen
- update localization files with new intro strings

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a344f6f908331a663c759df8232da