### PR TITLE
Fix profile image circle and overlay calls

### DIFF
--- a/lib/feature/auth/presentation/views/complete_profile_screen.dart
+++ b/lib/feature/auth/presentation/views/complete_profile_screen.dart
@@ -557,35 +557,35 @@ class _CompleteProfileScreenState extends State<CompleteProfileScreen>
                                           )
                                         ],
                                       ),
-                                      child: CircleAvatar(
-                                        radius: 62,
-                                        backgroundColor: Colors.transparent,
-                                        backgroundImage:
-                                        _profileImage != null
-                                            ? FileImage(_profileImage!)
-                                        as ImageProvider
-                                            : (_existingPicUrl != null &&
-                                            _existingPicUrl!
-                                                .trim()
-                                                .isNotEmpty
-                                            ? NetworkImage(
-                                            ApiConstants.baseUrl +
-                                                _existingPicUrl!)
-                                            : null),
+                                      child: Container(
+                                        width: 126,
+                                        height: 126,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          image: _profileImage != null
+                                              ? DecorationImage(
+                                                  image: FileImage(_profileImage!),
+                                                  fit: BoxFit.cover,
+                                                )
+                                              : (_existingPicUrl != null &&
+                                                      _existingPicUrl!.trim().isNotEmpty)
+                                                  ? DecorationImage(
+                                                      image: NetworkImage(
+                                                          ApiConstants.baseUrl + _existingPicUrl!),
+                                                      fit: BoxFit.cover,
+                                                    )
+                                                  : null,
+                                        ),
                                         child: (_profileImage == null &&
-                                            (_existingPicUrl == null ||
-                                                _existingPicUrl!
-                                                    .trim()
-                                                    .isEmpty))
+                                                (_existingPicUrl == null ||
+                                                    _existingPicUrl!.trim().isEmpty))
                                             ? Icon(
-                                          Icons.camera_alt,
-                                          size: 42,
-                                          color: isDark
-                                              ? Colors.white
-                                              .withOpacity(0.7)
-                                              : Colors.white
-                                              .withOpacity(0.7),
-                                        )
+                                                Icons.camera_alt,
+                                                size: 42,
+                                                color: isDark
+                                                    ? Colors.white.withOpacity(0.7)
+                                                    : Colors.white.withOpacity(0.7),
+                                              )
                                             : null,
                                       ),
                                     ),

--- a/lib/feature/auth/presentation/views/friend_book.dart
+++ b/lib/feature/auth/presentation/views/friend_book.dart
@@ -724,7 +724,7 @@ class _FriendBookScreenState extends State<FriendBookScreen>
             ),
           ),
         ),
-          if (_showIntro) _buildIntroOverlay(context),
+          if (_showIntro) _buildIntroOverlay(),
         ],
       ),
     );

--- a/lib/feature/auth/presentation/views/friend_list_screen.dart
+++ b/lib/feature/auth/presentation/views/friend_list_screen.dart
@@ -577,7 +577,7 @@ class _FriendListScreenState extends State<FriendListScreen>
             ),
             ),
           ),
-          if (_showIntro) _buildIntroOverlay(context),
+          if (_showIntro) _buildIntroOverlay(),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- ensure profile picture fills circular frame
- remove invalid context argument from intro overlays

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a38f85fd0833191588ae3be0d51e7