### PR TITLE
Add unread notification count feature

### DIFF
--- a/lib/config/api_endpoints.dart
+++ b/lib/config/api_endpoints.dart
@@ -24,6 +24,8 @@ abstract final class ApiConstants {
   static const String sendFriendNotification =
       "${_apiBaseUrl}send_friend_notification";
   static const String deleteNotification = "${_apiBaseUrl}delete_notification";
+  static const String getNotificationCount =
+      "${_apiBaseUrl}get_notification_count";
   static const String getSubPlan = "${_apiBaseUrl}get_subscription_plans";
   static const String getTransaction = "${_apiBaseUrl}get_transactions_by_email";
 }

--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -112,6 +112,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   DateTime? _trialExpiresAt;
   String? _trialMessage;
   bool _trialLoading = true;
+  int _unreadNotificationCount = 0;
 
   @override
   void initState() {
@@ -122,6 +123,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     _loadSettings().then((_) async {
       await _checkTrialStatus();
       _checkAndUpdateSubscription();
+      await _fetchUnreadNotificationCount();
       _runItemAnimation();
     });
 
@@ -355,6 +357,25 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       }
     } catch (e) {
       debugPrint('Subscription check failed: $e');
+    }
+  }
+
+  Future<void> _fetchUnreadNotificationCount() async {
+    if (_email.isEmpty) return;
+    try {
+      final uri = Uri.parse(ApiConstants.getNotificationCount)
+          .replace(queryParameters: {'email': _email});
+      final resp = await http.get(uri);
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        if (mounted) {
+          setState(() =>
+              _unreadNotificationCount =
+                  data['unread_notification_count'] ?? 0);
+        }
+      }
+    } catch (_) {
+      // ignore errors silently
     }
   }
 
@@ -1411,22 +1432,49 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                       actions: [
                         Padding(
                           padding: const EdgeInsets.only(right: 10),
-                          child: IconButton(
-                            icon: Icon(
-                              Icons.notifications_none,
-                              color: _isDarkMode
-                                  ? Colors.cyanAccent
-                                  : Colors.deepPurple,
-                              size: 27,
-                            ),
-                            onPressed: () {
-                              context.pushNamed(
-                                'notificationScreen',
-                                extra: {'isDarkMode': _isDarkMode},
-                              );
-                            },
-                            splashRadius: 26,
-                            tooltip: 'Notifications',
+                          child: Stack(
+                            children: [
+                              IconButton(
+                                icon: Icon(
+                                  Icons.notifications_none,
+                                  color: _isDarkMode
+                                      ? Colors.cyanAccent
+                                      : Colors.deepPurple,
+                                  size: 27,
+                                ),
+                                onPressed: () async {
+                                  await context.pushNamed(
+                                    'notificationScreen',
+                                    extra: {'isDarkMode': _isDarkMode},
+                                  );
+                                  _fetchUnreadNotificationCount();
+                                },
+                                splashRadius: 26,
+                                tooltip: 'Notifications',
+                              ),
+                              if (_unreadNotificationCount > 0)
+                                Positioned(
+                                  right: 4,
+                                  top: 4,
+                                  child: Container(
+                                    padding: const EdgeInsets.all(2),
+                                    decoration: const BoxDecoration(
+                                      color: Colors.redAccent,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    constraints:
+                                        const BoxConstraints(minWidth: 16, minHeight: 16),
+                                    child: Text(
+                                      '$_unreadNotificationCount',
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 10,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary
- add API constant for unread notification count
- fetch unread notification count on HomeScreen
- display unread count badge on notifications icon

## Testing
- `flutter` commands could not run because Flutter is not installed in the environment

------
https://chatgpt.com/codex/tasks/task_e_687f6ba22ad8833196506b57d236ccce