### PR TITLE
Add notification read API call

### DIFF
--- a/lib/config/api_endpoints.dart
+++ b/lib/config/api_endpoints.dart
@@ -26,6 +26,8 @@ abstract final class ApiConstants {
   static const String deleteNotification = "${_apiBaseUrl}delete_notification";
   static const String getNotificationCount =
       "${_apiBaseUrl}get_notification_count";
+  static const String notificationReaded =
+      "${_apiBaseUrl}notification_readed";
   static const String getSubPlan = "${_apiBaseUrl}get_subscription_plans";
   static const String getTransaction = "${_apiBaseUrl}get_transactions_by_email";
 }

--- a/lib/feature/auth/presentation/views/notification_screen.dart
+++ b/lib/feature/auth/presentation/views/notification_screen.dart
@@ -58,6 +58,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
     final prefs = await SharedPreferences.getInstance();
     _userEmail = prefs.getString('email') ?? '';
     await _fetchNotifications();
+    await _markNotificationsAsRead();
   }
 
   void showAccountDeletedDialog() {
@@ -248,6 +249,16 @@ class _NotificationScreenState extends State<NotificationScreen> {
       );
     } finally {
       setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _markNotificationsAsRead() async {
+    try {
+      final uri = Uri.parse(ApiConstants.notificationReaded)
+          .replace(queryParameters: {'email': _userEmail});
+      await http.post(uri);
+    } catch (_) {
+      // Ignore errors
     }
   }
 


### PR DESCRIPTION
## Summary
- add `notificationReaded` endpoint constant
- call API to mark notifications as read when opening notification screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e0a744c8331923b8e1bb71827b6