### PR TITLE
Fix premium refresh

### DIFF
--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -685,6 +685,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     await prefs.setBool('isSubscribed', true);
     setState(() => _isSubscribed = true);
     await _checkAndUpdateSubscription(showSnackBar: true);
+    await _checkTrialStatus();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
@@ -1044,6 +1045,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     _isSubscribed = true;
                   });
                   await _checkAndUpdateSubscription(showSnackBar: true);
+                  await _checkTrialStatus();
                   Navigator.of(context).pop();
                 } else {
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(


### PR DESCRIPTION
## Summary
- update home screen subscription success handlers to refresh trial status

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7014cc6083318f94842ad15dd696