### PR TITLE
Implement FCM push in chat

### DIFF
--- a/lib/config/firebase_push.dart
+++ b/lib/config/firebase_push.dart
@@ -1,0 +1,3 @@
+class FcmConfig {
+  static const String serverKey = 'YOUR_SERVER_KEY_HERE';
+}

--- a/lib/core/utils/routing/routes_generator.dart
+++ b/lib/core/utils/routing/routes_generator.dart
@@ -120,6 +120,7 @@ final GoRouter appRouter = GoRouter(
           name: args['name'] ?? '',
           phoneNumber: args['phoneNumber'] ?? '',
           id: args['id'] ?? '',
+          token: args['token'] as String?,
           isDarkMode: isDarkMode,
         );
       },

--- a/lib/feature/auth/presentation/views/chat_screen.dart
+++ b/lib/feature/auth/presentation/views/chat_screen.dart
@@ -8,12 +8,14 @@ import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/scheduler.dart';
+import '../../../config/firebase_push.dart';
 import '../../../../core/network/http_service.dart';
 
 class ChatScreen extends StatefulWidget {
   final String name;
   final String phoneNumber;
   final String id;
+  final String? token;
   final bool isDarkMode;
 
   const ChatScreen({
@@ -21,6 +23,7 @@ class ChatScreen extends StatefulWidget {
     required this.name,
     required this.phoneNumber,
     required this.id,
+    this.token,
     this.isDarkMode = false,
   }) : super(key: key);
 
@@ -107,7 +110,6 @@ class _ChatScreenState extends State<ChatScreen> {
     });
     _sendNotification(
       fromEmail: _userEmail!,
-      toEmail: widget.id,
       message: text,
     );
     _scrollToLatest();
@@ -115,18 +117,27 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Future<void> _sendNotification({
     required String fromEmail,
-    required String toEmail,
     required String message,
   }) async {
+    if (widget.token == null || widget.token!.isEmpty) return;
     try {
-      final url = Uri.parse(ApiConstants.sendNotification);
+      final url = Uri.parse('https://fcm.googleapis.com/fcm/send');
       final response = await http.post(
         url,
-        body: {
-          'from_email': fromEmail,
-          'to_email': toEmail,
-          'message': message,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'key=${FcmConfig.serverKey}',
         },
+        body: jsonEncode({
+          'to': widget.token,
+          'notification': {
+            'title': fromEmail,
+            'body': message,
+          },
+          'data': {
+            'click_action': 'FLUTTER_NOTIFICATION_CLICK',
+          },
+        }),
       );
       if (response.statusCode != 200) {
         debugPrint('Notification failed: ${response.statusCode}');

--- a/lib/feature/auth/presentation/views/friend_book.dart
+++ b/lib/feature/auth/presentation/views/friend_book.dart
@@ -9,6 +9,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../../core/utils/routing/routes.dart';
 
+class FriendData {
+  final String email;
+  final String? token;
+
+  FriendData({required this.email, this.token});
+}
+
 class FriendBookScreen extends StatefulWidget {
   final String phoneNumber;
   final bool isDarkMode;
@@ -27,7 +34,7 @@ class _FriendBookScreenState extends State<FriendBookScreen>
     with TickerProviderStateMixin {
   bool _loading = true;
   String? _error;
-  List<String> _friendEmails = [];
+  List<FriendData> _friends = [];
   String _email = '';
   bool _showIntro = false;
 
@@ -85,7 +92,7 @@ class _FriendBookScreenState extends State<FriendBookScreen>
     setState(() {
       _loading = true;
       _error = null;
-      _friendEmails = [];
+      _friends = [];
     });
 
     try {
@@ -106,15 +113,18 @@ class _FriendBookScreenState extends State<FriendBookScreen>
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         final rawList = data['friends'] as List<dynamic>? ?? [];
-        List<String> parsedEmails = [];
+        List<FriendData> parsed = [];
         for (var entry in rawList) {
           final map = entry as Map<String, dynamic>;
           final email = (map['email'] ?? '').toString().trim();
-          if (email.isNotEmpty) parsedEmails.add(email);
+          final token = map['fcm_token']?.toString();
+          if (email.isNotEmpty) {
+            parsed.add(FriendData(email: email, token: token));
+          }
         }
-        print('Loaded friend emails: $parsedEmails');
+        print('Loaded friends: \$parsed');
         setState(() {
-          _friendEmails = parsedEmails;
+          _friends = parsed;
         });
         _listAnimController.forward(from: 0);
       } else {
@@ -543,15 +553,16 @@ class _FriendBookScreenState extends State<FriendBookScreen>
                 ? Colors.grey[900]!
                 : Colors.white,
             edgeOffset: 20,
-            child: _friendEmails.isEmpty
+            child: _friends.isEmpty
                 ? _NoFriendsWidget(isDarkMode: widget.isDarkMode)
                 : ListView.builder(
               physics: const AlwaysScrollableScrollPhysics(),
               padding: const EdgeInsets.only(
                   top: 12, left: 18, right: 18, bottom: 40),
-              itemCount: _friendEmails.length,
+              itemCount: _friends.length,
               itemBuilder: (_, i) {
-                final friendEmail = _friendEmails[i];
+                final friendData = _friends[i];
+                final friendEmail = friendData.email;
                 final displayName = friendEmail.split('@').first;
                 final avatarColors =
                 _avatarGradients[i % _avatarGradients.length];
@@ -692,9 +703,9 @@ class _FriendBookScreenState extends State<FriendBookScreen>
                                       'chatList',
                                       extra: {
                                         'name': displayName,
-                                        'phoneNumber':
-                                        widget.phoneNumber,
+                                        'phoneNumber': widget.phoneNumber,
                                         'id': friendEmail,
+                                        'token': friendData.token ?? '',
                                         friendEmail: friendEmail,
                                         'isDarkMode': _isDarkMode.toString()
 


### PR DESCRIPTION
## Summary
- parse fcm_token from friends API
- pass the token when opening a chat
- send push notification directly via FCM using the friend's token
- add constant holder for FCM server key

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7fb9be448331b07ceeab865485ba