### PR TITLE
Add Cloud Function for FCM and update client code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+### Push Notifications
+
+This project sends FCM notifications through a Firebase Cloud Function. Deploy
+the function found in `functions/` and update `FcmConfig.functionUrl` in
+`lib/config/firebase_push.dart` with the HTTPS endpoint provided by Firebase.

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,25 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+exports.sendNotification = functions.https.onRequest(async (req, res) => {
+  const { token, title, body } = req.body;
+
+  if (!token || !title || !body) {
+    res.status(400).send('Missing parameters');
+    return;
+  }
+
+  try {
+    await admin.messaging().send({
+      token,
+      notification: { title, body },
+      data: { click_action: 'FLUTTER_NOTIFICATION_CLICK' },
+    });
+    res.status(200).send('Notification sent');
+  } catch (err) {
+    console.error('Notification error:', err);
+    res.status(500).send('Notification error');
+  }
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "firebase-functions",
+  "description": "Cloud Functions for FCM",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  },
+  "engines": {
+    "node": "18"
+  }
+}

--- a/lib/config/firebase_push.dart
+++ b/lib/config/firebase_push.dart
@@ -1,3 +1,5 @@
 class FcmConfig {
   static const String serverKey = 'YOUR_SERVER_KEY_HERE';
+  /// HTTPS endpoint of the Cloud Function that sends FCM messages.
+  static const String functionUrl = 'https://<YOUR_CLOUD_FUNCTION_URL>';
 }

--- a/lib/feature/auth/presentation/views/chat_screen.dart
+++ b/lib/feature/auth/presentation/views/chat_screen.dart
@@ -120,22 +120,16 @@ class _ChatScreenState extends State<ChatScreen> {
   }) async {
     if (widget.token == null || widget.token!.isEmpty) return;
     try {
-      final url = Uri.parse('https://fcm.googleapis.com/fcm/send');
+      final url = Uri.parse(FcmConfig.functionUrl);
       final response = await http.post(
         url,
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'key=${FcmConfig.serverKey}',
         },
         body: jsonEncode({
-          'to': widget.token,
-          'notification': {
-            'title': fromEmail,
-            'body': message,
-          },
-          'data': {
-            'click_action': 'FLUTTER_NOTIFICATION_CLICK',
-          },
+          'token': widget.token,
+          'title': fromEmail,
+          'body': message,
         }),
       );
       if (response.statusCode != 200) {


### PR DESCRIPTION
## Summary
- add `functions/` with a simple Firebase Cloud Function for sending FCM messages
- update `FcmConfig` with a placeholder `functionUrl`
- modify `chat_screen.dart` to call the Cloud Function instead of the legacy API
- document push notification setup in `README`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f832a1e888331909b3b3224c46f09