### PR TITLE
Fix FCM notification data

### DIFF
--- a/lib/feature/auth/presentation/views/chat_screen.dart
+++ b/lib/feature/auth/presentation/views/chat_screen.dart
@@ -107,11 +107,15 @@ class _ChatScreenState extends State<ChatScreen> {
       'receiver': widget.id,
       'timestamp': FieldValue.serverTimestamp(),
     });
-    _sendNotification(
-      fromEmail: 'vivek@example.com',
-      message: 'Hello there!',
-      receiverToken: '<your friend’s FCM token>',
-    );
+    if (widget.token != null && widget.token!.isNotEmpty) {
+      _sendNotification(
+        fromEmail: _userEmail!,
+        message: text,
+        receiverToken: widget.token!,
+      );
+    } else {
+      debugPrint('❗ Receiver FCM token missing, notification not sent');
+    }
 
     _scrollToLatest();
   }


### PR DESCRIPTION
## Summary
- send FCM notifications with the actual sender email, message text and token

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb85355608331b70b8d1e95970876