### PR TITLE
Fix speaker list refresh and add pull-to-refresh

### DIFF
--- a/lib/feature/auth/presentation/views/add_contact_screen.dart
+++ b/lib/feature/auth/presentation/views/add_contact_screen.dart
@@ -493,7 +493,7 @@ class _AddContactScreenState extends State<AddContactScreen>
           );
           await Future.delayed(const Duration(milliseconds: 800));
           if (!mounted) return;
-          context.go('/speakerScreen?phoneNumber=${Uri.encodeComponent(widget.phoneNumber)}&isDarkMode=${widget.isDarkMode}');
+          context.pop(true);
         }
       } else {
         setState(() => _showTryAgain = true);

--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -379,6 +379,13 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
   }
 
+  Future<void> _refreshHome() async {
+    await _loadSettings();
+    await _checkTrialStatus();
+    await _checkAndUpdateSubscription();
+    await _fetchUnreadNotificationCount();
+  }
+
   Future<void> _checkFirstLaunch() async {
     final prefs = await SharedPreferences.getInstance();
     final didTutorial = prefs.getBool('didHomeTutorial') ?? false;
@@ -1704,9 +1711,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 ),
               ),
             Expanded(
-              child: ListView(
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                children: [
+              child: RefreshIndicator(
+                onRefresh: _refreshHome,
+                child: ListView(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  children: [
                   GlassmorphicContainer(
                     width: double.infinity,
                     height: 200,

--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -236,8 +236,17 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
 
     return response;
   }
-  void _goToAddSpeaker() {
-    context.push('/addContact', extra: {'phoneNumber': widget.phoneNumber, 'isDarkMode': widget.isDarkMode});
+  Future<void> _goToAddSpeaker() async {
+    final result = await context.push<bool>(
+      '/addContact',
+      extra: {
+        'phoneNumber': widget.phoneNumber,
+        'isDarkMode': widget.isDarkMode,
+      },
+    );
+    if (result == true) {
+      await _fetchSpeakers();
+    }
   }
   Future<void> _deleteSpeaker(Speaker s) async {
     final endpoint = Uri.parse(ApiConstants.deleteSpeaker);
@@ -500,9 +509,10 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                 edgeOffset: 20,
                 child: _speakers.isEmpty
                     ? _NoSpeakersWidget(
-                  isDarkMode: widget.isDarkMode,
-                  phoneNumber: widget.phoneNumber,
-                )
+                        isDarkMode: widget.isDarkMode,
+                        phoneNumber: widget.phoneNumber,
+                        onAdd: _goToAddSpeaker,
+                      )
                     : ListView.builder(
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.only(top: 12, left: 18, right: 18, bottom: 40),
@@ -743,9 +753,11 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
 class _NoSpeakersWidget extends StatelessWidget {
   final bool isDarkMode;
   final String phoneNumber;
+  final Future<void> Function() onAdd;
   const _NoSpeakersWidget({
     required this.isDarkMode,
     required this.phoneNumber,
+    required this.onAdd,
   });
 
   @override
@@ -796,10 +808,7 @@ class _NoSpeakersWidget extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                   color: isDarkMode ? Colors.black : Colors.white),
             ),
-            onPressed: () {
-              context.push('/addContact',
-                  extra: {'phoneNumber': phoneNumber, 'isDarkMode': isDarkMode});
-            },
+            onPressed: onAdd,
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- return `true` on successful speaker addition
- refresh speaker list when returning from the add speaker screen
- allow the empty speaker widget to trigger add speaker
- enable pull‑to‑refresh on the home screen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fbba127b88331bf2be684060f597c