### PR TITLE
Add native language transcription option

### DIFF
--- a/lib/config/api_endpoints.dart
+++ b/lib/config/api_endpoints.dart
@@ -19,9 +19,11 @@ abstract final class ApiConstants {
  static const String logoutUser = "${_apiBaseUrl}logout_user";
  static const String addFriend = "${_apiBaseUrl}add_friend";
  static const String deleteFriends = "${_apiBaseUrl}delete_friend";
- static const String deleteSpeaker = "${_apiBaseUrl}delete_speaker";
- static const String identifySpeaker = "${_apiBaseUrl}identify_speaker";
- static const String updateUserProfile =  "${_apiBaseUrl}update_user_profile";
+  static const String deleteSpeaker = "${_apiBaseUrl}delete_speaker";
+  static const String identifySpeaker = "${_apiBaseUrl}identify_speaker";
+  static const String identifySpeakerNative =
+      "${_apiBaseUrl}identify_speaker_native";
+  static const String updateUserProfile =  "${_apiBaseUrl}update_user_profile";
  static const String getNotification = "${_apiBaseUrl}get_notifications";
  static const String sendNotification = "${_apiBaseUrl}send_notification";
  static const String sendFriendNotification =

--- a/lib/demo.dart
+++ b/lib/demo.dart
@@ -57,6 +57,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
 
 
   bool _speakOnMeeting = true;
+  bool _showTextMyLanguage = false;
 
   final List<_AudioQueueItem> _audioQueue = [];
   bool _isApiProcessing = false;
@@ -87,6 +88,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     _initUser();
     _initTTS();
     _loadSpeakOnMeeting();
+    _loadShowTextMyLanguage();
     _scrollController = ScrollController();
     _scrollController.addListener(_handleScroll);
 
@@ -146,6 +148,13 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     final prefs = await SharedPreferences.getInstance();
     setState(() {
       _speakOnMeeting = prefs.getBool('speakOnMeeting') ?? true;
+    });
+  }
+
+  Future<void> _loadShowTextMyLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _showTextMyLanguage = prefs.getBool('useNativeApi') ?? false;
     });
   }
 
@@ -378,9 +387,10 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     final prefs = await SharedPreferences.getInstance();
     final storedEmail = prefs.getString('email') ?? '';
 
-    Uri uri = Uri.parse(
-      '${ApiConstants.baseUrl}/identify_speaker?email=$storedEmail&label=$label',
-    );
+    final base = _showTextMyLanguage
+        ? ApiConstants.identifySpeakerNative
+        : ApiConstants.identifySpeaker;
+    Uri uri = Uri.parse('$base?email=$storedEmail&label=$label');
     void showAccountDeletedDialog() {
       showGeneralDialog(
         context: context,

--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -58,6 +58,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
   final String _appLanguageCode = 'en';
 
   bool _speakOnMeeting = true;
+  bool _showTextMyLanguage = false;
 
   final List<_AudioQueueItem> _audioQueue = [];
   bool _isApiProcessing = false;
@@ -88,6 +89,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     _initUser();
     _initTTS();
     _loadSpeakOnMeeting();
+    _loadShowTextMyLanguage();
     _scrollController = ScrollController();
     _scrollController.addListener(_handleScroll);
 
@@ -147,6 +149,13 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     final prefs = await SharedPreferences.getInstance();
     setState(() {
       _speakOnMeeting = prefs.getBool('speakOnMeeting') ?? true;
+    });
+  }
+
+  Future<void> _loadShowTextMyLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _showTextMyLanguage = prefs.getBool('useNativeApi') ?? false;
     });
   }
 
@@ -387,9 +396,10 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     final prefs = await SharedPreferences.getInstance();
     final storedEmail = prefs.getString('email') ?? '';
 
-    Uri uri = Uri.parse(
-      '${ApiConstants.baseUrl}/identify_speaker?email=$storedEmail&label=$label',
-    );
+    final base = _showTextMyLanguage
+        ? ApiConstants.identifySpeakerNative
+        : ApiConstants.identifySpeaker;
+    Uri uri = Uri.parse('$base?email=$storedEmail&label=$label');
     void showAccountDeletedDialog() {
       showGeneralDialog(
         context: context,
@@ -551,7 +561,11 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
             final text = data['spoken_text'] as String? ?? '';
             final time = TimeOfDay.now().format(context);
 
-            if (text.trim().isEmpty || !_isTextInLanguage(text, _appLanguageCode)) {
+            if (text.trim().isEmpty) {
+              continue;
+            }
+            if (!_showTextMyLanguage &&
+                !_isTextInLanguage(text, _appLanguageCode)) {
               continue;
             }
 

--- a/lib/feature/auth/presentation/views/setting_screen.dart
+++ b/lib/feature/auth/presentation/views/setting_screen.dart
@@ -19,6 +19,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _isDarkMode;
   bool _notificationsEnabled = true;
   bool _speakOnMeeting = true;
+  bool _showTextMyLanguage = false;
 
   @override
   void initState() {
@@ -32,6 +33,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() {
       _notificationsEnabled = prefs.getBool('notifications') ?? true;
       _speakOnMeeting = prefs.getBool('speakOnMeeting') ?? true;
+      _showTextMyLanguage = prefs.getBool('useNativeApi') ?? false;
     });
   }
 
@@ -45,6 +47,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('speakOnMeeting', value);
     setState(() => _speakOnMeeting = value);
+  }
+
+  Future<void> _updateShowTextMyLanguage(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('useNativeApi', value);
+    setState(() => _showTextMyLanguage = value);
   }
 
   void _navigateToTerms() {
@@ -211,15 +219,43 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           _isDarkMode ? Colors.white70 : Colors.grey.shade700,
                     ),
                   ),
-                  value: _speakOnMeeting,
-                  onChanged: _updateSpeakOnMeeting,
-                ),
+                value: _speakOnMeeting,
+                onChanged: _updateSpeakOnMeeting,
               ),
-              const SizedBox(height: 16),
-              Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+              elevation: 4,
+              color: _isDarkMode
+                  ? Colors.black.withOpacity(0.5)
+                  : Colors.white.withOpacity(0.84),
+              child: SwitchListTile(
+                title: Row(
+                  children: [
+                    const Icon(Icons.translate, color: Colors.deepPurple),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        context.loc.showTextMyLanguage,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: _isDarkMode ? Colors.white : Colors.black,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
+                value: _showTextMyLanguage,
+                onChanged: _updateShowTextMyLanguage,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
                 elevation: 5,
                 margin: const EdgeInsets.symmetric(vertical: 8),
                 child: InkWell(

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -18,6 +18,7 @@
   "notifications": "নোটিফিকেশন",
   "noNotificationFound": "কোনো নোটিফিকেশন পাওয়া যায়নি!",
   "speakMyMsg": "মিটিং-এ আমার বার্তা বলুন",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe": "আপনার বার্তাগুলি সবাইকে জোরে বলা হবে।",
   "yourMsgWillNotBe": "আপনার বার্তাগুলি স্বয়ংক্রিয়ভাবে বলা হবে না। আপনি প্লে-তে ট্যাপ করে বলাতে পারেন।",
   "myTransactions": "আমার লেনদেনসমূহ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -18,6 +18,7 @@
   "notifications": "Notifications",
   "noNotificationFound":"No notifications found!",
   "speakMyMsg":"Speak my messages in meetings",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe":"Your messages will be spoken aloud to everyone.",
   "yourMsgWillNotBe":"Your messages will not be auto-spoken. You can tap play to speak.",
   "myTransactions":"My Transactions",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -18,6 +18,7 @@
   "notifications": "નોટિફિકેશન્સ",
   "noNotificationFound": "કોઈ નોટિફિકેશન મળ્યાં નથી!",
   "speakMyMsg": "મીટિંગમાં મારા સંદેશાઓ બોલો",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe": "તમારા સંદેશાઓ દરેકને મોટા અવાજે બોલવામાં આવશે.",
   "yourMsgWillNotBe": "તમારા સંદેશાઓ આપમેળે બોલવામાં આવશે નહીં. તમે બોલાવવા માટે પ્લે પર ટેપ કરી શકો છો.",
   "myTransactions": "મારી ટ્રાન્ઝેક્શન્સ",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -19,6 +19,7 @@
   "notifications": "सूचनाएं",
   "noNotificationFound": "कोई सूचना नहीं मिली!",
   "speakMyMsg":"सभाओं में अपना संदेश बोलो",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe":"आपके संदेश सभी को जोर से सुनाए जाएंगे।",
   "yourMsgWillNotBe":"आपके संदेश स्वतः बोले नहीं जाएंगे। बोलने के लिए आप प्ले पर टैप कर सकते हैं।",
   "myTransactions":"मेरे लेन-देन",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -18,6 +18,7 @@
   "notifications": "सूचना",
   "noNotificationFound": "कोणतीही सूचना मिळाली नाहीत!",
   "speakMyMsg": "मिटिंगमध्ये माझे संदेश बोला",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe": "तुमचे संदेश सर्वांना मोठ्याने सांगितले जातील.",
   "yourMsgWillNotBe": "तुमचे संदेश आपोआप सांगितले जाणार नाहीत. बोलण्यासाठी प्लेवर टॅप करा.",
   "myTransactions": "माझे व्यवहार",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -18,6 +18,7 @@
   "notifications": "ਸੂਚਨਾਵਾਂ",
   "noNotificationFound": "ਕੋਈ ਸੂਚਨਾਵਾਂ ਨਹੀਂ ਮਿਲੀਆਂ!",
   "speakMyMsg":"ਮੀਟਿੰਗਾਂ ਵਿੱਚ ਮੇਰੇ ਸੁਨੇਹੇ ਬੋਲੋ",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe":"ਤੁਹਾਡੇ ਸੁਨੇਹੇ ਸਾਰਿਆਂ ਨੂੰ ਉੱਚੀ ਆਵਾਜ਼ ਵਿੱਚ ਸੁਣਾਏ ਜਾਣਗੇ।.",
   "yourMsgWillNotBe":"ਤੁਹਾਡੇ ਸੁਨੇਹੇ ਆਟੋ-ਸਪੋਕਨ ਨਹੀਂ ਹੋਣਗੇ। ਤੁਸੀਂ ਬੋਲਣ ਲਈ ਚਲਾਓ 'ਤੇ ਟੈਪ ਕਰ ਸਕਦੇ ਹੋ।",
   "myTransactions":"ਮੇਰੇ ਲੈਣ-ਦੇਣ",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -18,6 +18,7 @@
   "notifications": "அறிவிப்புகள்",
   "noNotificationFound": "அறிவிப்புகள் எதுவும் இல்லை!",
   "speakMyMsg": "கூட்டங்களில் என் செய்திகளை பேசவும்",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe": "உங்கள் செய்திகள் அனைவருக்கும் உரக்க பேசப்படும்.",
   "yourMsgWillNotBe": "உங்கள் செய்திகள் தானாகவே பேசப்படாது. பேசும் வகையில் play ஐ தட்டவும்.",
   "myTransactions": "என் பரிவர்த்தனைகள்",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -18,6 +18,7 @@
   "notifications": "اطلاعات",
   "noNotificationFound": "کوئی اطلاع نہیں ملی!",
   "speakMyMsg": "میٹنگز میں میرے پیغامات بولیں",
+  "showTextMyLanguage": "Show text in my language",
   "yourMsgWillBe": "آپ کے پیغامات سب کو اونچی آواز میں سنائے جائیں گے۔",
   "yourMsgWillNotBe": "آپ کے پیغامات خود بخود نہیں سنائے جائیں گے۔ آپ بولنے کے لیے پلے پر ٹیپ کر سکتے ہیں۔",
   "myTransactions": "میرے لین دین",


### PR DESCRIPTION
## Summary
- expose `identifySpeakerNative` endpoint
- allow toggling native-language transcription in settings
- load this setting in group conversation screens
- hit `/identify_speaker_native` when the option is enabled
- update localization resources with a new key

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b5843df74833180b7803275464581