### PR TITLE
Move language toggle to conversation screen

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -160,6 +160,13 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     });
   }
 
+  Future<void> _toggleShowTextMyLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final newVal = !_showTextMyLanguage;
+    await prefs.setBool('useNativeApi', newVal);
+    setState(() => _showTextMyLanguage = newVal);
+  }
+
   Future<void> _loadAppLanguageCode() async {
     final prefs = await SharedPreferences.getInstance();
     final code = prefs.getString('language_code');
@@ -795,6 +802,53 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
                     ),
                   );
                 },
+                splashRadius: 26,
+              ),
+            ),
+          ),
+          Tooltip(
+            message: context.loc.showTextMyLanguage,
+            verticalOffset: 30,
+            child: Container(
+              margin: const EdgeInsets.only(right: 10),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(16),
+                gradient: LinearGradient(
+                  colors: widget.isDarkMode
+                      ? [Colors.cyanAccent.withOpacity(0.14), Colors.blueAccent.withOpacity(0.13)]
+                      : [Colors.deepPurpleAccent.withOpacity(0.11), Colors.amber.withOpacity(0.14)],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: widget.isDarkMode
+                        ? Colors.cyanAccent.withOpacity(0.13)
+                        : Colors.deepPurpleAccent.withOpacity(0.07),
+                    blurRadius: 10,
+                    offset: Offset(0, 3),
+                  ),
+                ],
+              ),
+              child: IconButton(
+                icon: Icon(
+                  Icons.translate,
+                  color: _showTextMyLanguage
+                      ? Colors.greenAccent
+                      : widget.isDarkMode
+                          ? Colors.cyanAccent
+                          : Colors.deepPurpleAccent,
+                  size: 27,
+                  shadows: [
+                    Shadow(
+                      color: widget.isDarkMode
+                          ? Colors.cyanAccent.withOpacity(0.22)
+                          : Colors.deepPurpleAccent.withOpacity(0.11),
+                      blurRadius: 9,
+                    ),
+                  ],
+                ),
+                onPressed: _toggleShowTextMyLanguage,
                 splashRadius: 26,
               ),
             ),

--- a/lib/feature/auth/presentation/views/setting_screen.dart
+++ b/lib/feature/auth/presentation/views/setting_screen.dart
@@ -19,7 +19,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _isDarkMode;
   bool _notificationsEnabled = true;
   bool _speakOnMeeting = true;
-  bool _showTextMyLanguage = false;
 
   @override
   void initState() {
@@ -33,7 +32,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() {
       _notificationsEnabled = prefs.getBool('notifications') ?? true;
       _speakOnMeeting = prefs.getBool('speakOnMeeting') ?? true;
-      _showTextMyLanguage = prefs.getBool('useNativeApi') ?? false;
     });
   }
 
@@ -49,11 +47,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _speakOnMeeting = value);
   }
 
-  Future<void> _updateShowTextMyLanguage(bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('useNativeApi', value);
-    setState(() => _showTextMyLanguage = value);
-  }
 
   void _navigateToTerms() {
     context.pushNamed(
@@ -221,34 +214,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ),
                 value: _speakOnMeeting,
                 onChanged: _updateSpeakOnMeeting,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Card(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
-              elevation: 4,
-              color: _isDarkMode
-                  ? Colors.black.withOpacity(0.5)
-                  : Colors.white.withOpacity(0.84),
-              child: SwitchListTile(
-                title: Row(
-                  children: [
-                    const Icon(Icons.translate, color: Colors.deepPurple),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        context.loc.showTextMyLanguage,
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          color: _isDarkMode ? Colors.white : Colors.black,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                value: _showTextMyLanguage,
-                onChanged: _updateShowTextMyLanguage,
               ),
             ),
             const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- add toggle for showing text in user's language to `GroupSpeechToTextScreen`
- persist this preference and remove old toggle from settings

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b5d90922483319cde28180da7293d