### PR TITLE
Fix font handling for Hindi text

### DIFF
--- a/lib/config/app_strings.dart
+++ b/lib/config/app_strings.dart
@@ -1,6 +1,8 @@
 class AppStrings {
   static const String appName = "My App";
-  static const String fontFamily = "My App";
+  // Leave empty to use the system default font which properly supports
+  // languages like Hindi.
+  static const String fontFamily = "";
   static const String localDirectory = "My App";
   static const String loginTitle = "Login To Your Account";
   static const String verificationTitle = "Verification Code";

--- a/lib/feature/common_widgets/app_text.dart
+++ b/lib/feature/common_widgets/app_text.dart
@@ -73,7 +73,7 @@ class AppText extends StatelessWidget {
         fontSize: textSize,
         fontStyle: fontStyle ?? FontStyle.normal,
         height: lineHeight ?? 1.0,
-        fontFamily: fontFamily ?? AppStrings.fontFamily,
+        fontFamily: _resolveFontFamily(),
         decorationColor: underlineColor ?? AppColors.black,
         decorationThickness: 1,
         decoration: strikeThrough != null && strikeThrough!
@@ -81,6 +81,14 @@ class AppText extends StatelessWidget {
             : underline != null
                 ? TextDecoration.underline
                 : null);
+  }
+
+  String? _resolveFontFamily() {
+    final fam = fontFamily ?? AppStrings.fontFamily;
+    if (fam.isEmpty) {
+      return null;
+    }
+    return fam;
   }
   FontWeight getWeight() {
     switch (style) {

--- a/lib/feature/common_widgets/custom_toast.dart
+++ b/lib/feature/common_widgets/custom_toast.dart
@@ -53,7 +53,7 @@ void toast({required String msg, bool isError = true}) {
                           text: msg,
                           textAlign: TextAlign.center,
                           textSize: 15,
-                          fontFamily: AppStrings.verificationTitle,
+                          fontFamily: AppStrings.fontFamily,
                           color: isError ? Colors.red : Colors.green,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- allow system default font by emptying `AppStrings.fontFamily`
- resolve font at runtime in `AppText`
- use the default font in custom toast

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b62388bfc8331869483b68653405f