### PR TITLE
Handle multilingual API responses in group speech screen

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -576,7 +576,9 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
         return;
       }
       if (response.statusCode == 200) {
-        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        // Ensure proper decoding of multilingual text regardless of server headers
+        final decoded = utf8.decode(response.bodyBytes);
+        final body = jsonDecode(decoded) as Map<String, dynamic>;
         final speakers = body['speakers'] as List<dynamic>;
 
         setState(() {


### PR DESCRIPTION
## Summary
- Decode identify speaker API responses as UTF-8 to preserve native scripts in chat messages

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68996f1d11f48331baf55f057624214f