### PR TITLE
feat: resume speech recognition automatically

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -228,6 +228,11 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
       await _speakMyLastMessage(text);
     }
     if (_shouldAutoscroll) _scrollToBottom(animate: true);
+
+    // Restart listening to keep capturing subsequent speech input.
+    if (_isRecording) {
+      _startListening();
+    }
   }
 
   // Allow English and major Indian scripts so that Hindi or other


### PR DESCRIPTION
## Summary
- restart speech-to-text listening after each recognized phrase

## Testing
- `dart format lib/feature/auth/presentation/views/group_speach_text.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c60bca7108331a45851559da0fd66