### PR TITLE
feat: support native language speech recognition

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -179,15 +179,39 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     return s[0].toUpperCase() + s.substring(1);
   }
 
+  String _localeIdForLanguage(String code) {
+    switch (code) {
+      case 'hi':
+        return 'hi_IN';
+      case 'pa':
+        return 'pa_IN';
+      case 'gu':
+        return 'gu_IN';
+      case 'ta':
+        return 'ta_IN';
+      case 'mr':
+        return 'mr_IN';
+      case 'bn':
+        return 'bn_IN';
+      case 'ur':
+        return 'ur_IN';
+      default:
+        return 'en_US';
+    }
+  }
+
   Future<void> _startListening() async {
     final available = await _speech.initialize();
     if (!available) return;
     setState(() {
       _isRecording = true;
     });
+    final localeId =
+        _showTextMyLanguage ? _localeIdForLanguage(_appLanguageCode) : null;
     _speech.listen(
       onResult: _onSpeechResult,
       listenMode: ListenMode.dictation,
+      localeId: localeId,
       onSoundLevelChange: (level) {
         setState(() {
           _amplitude = level * 1000;


### PR DESCRIPTION
## Summary
- map supported language codes to speech recognition locales
- listen using selected locale when native language mode is enabled

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c65566a988331a6e41b4670be95ff