### PR TITLE
feat: show elevenlabs voices on speaker screen

### DIFF
--- a/lib/config/api_endpoints.dart
+++ b/lib/config/api_endpoints.dart
@@ -35,4 +35,9 @@ abstract final class ApiConstants {
      "${_apiBaseUrl}notification_readed";
  static const String getSubPlan = "${_apiBaseUrl}get_subscription_plans";
  static const String getTransaction = "${_apiBaseUrl}get_transactions_by_email";
+
+ // ElevenLabs endpoints
+ static const String elevenLabsApiKey = 'YOUR_ELEVENLABS_API_KEY';
+ static const String _elevenLabsBaseUrl = 'https://api.elevenlabs.io/v1';
+ static const String listElevenLabsVoices = "${_elevenLabsBaseUrl}/voices";
 }

--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -184,29 +184,33 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
       _speakers = [];
     });
     try {
-      final uri = Uri.parse('${ApiConstants.listSpeaker}$_email');
-      final resp = await http.get(uri);
+      // Fetch voices from ElevenLabs instead of the legacy list_speakers API
+      final uri = Uri.parse(ApiConstants.listElevenLabsVoices);
+      final resp = await http.get(uri, headers: {
+        'xi-api-key': ApiConstants.elevenLabsApiKey,
+      });
 
-      // ==== FIXED LOGIC ====
-      if (resp.statusCode == 204) {
-        await Future.delayed(const Duration(milliseconds: 600));
-        if (mounted) showAccountDeletedDialog();
-        setState(() {
-          _loading = false;
-        });
-        return;
-      } else if (resp.statusCode == 200) {
+      if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
-        final raw = data['speakers'] as List<dynamic>? ?? [];
+        final raw = data['voices'] as List<dynamic>? ?? [];
         setState(() {
-          _speakers = raw.map((e) => Speaker.fromJson(e as Map<String, dynamic>)).toList();
+          _speakers = raw
+              .map((e) => Speaker(
+                    id: e['voice_id'] as String,
+                    name: e['name'] as String? ?? '',
+                    email: '',
+                    embeddingCount:
+                        (e['samples'] is List) ? (e['samples'] as List).length : 0,
+                  ))
+              .toList();
           _error = null; // no error
         });
         _listAnimController.forward(from: 0);
+      } else if (resp.statusCode == 401) {
+        setState(() => _error = 'Invalid ElevenLabs API key');
       } else {
         setState(() => _error = 'Load failed: ${resp.statusCode}');
       }
-      // =====================
     } catch (e) {
       setState(() => _error = 'Error: $e');
     } finally {


### PR DESCRIPTION
## Summary
- fetch ElevenLabs voice list instead of legacy speaker endpoint
- add ElevenLabs API constants

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a405f454ac8331a2131fb592c0cd17