### PR TITLE
Display speaker names in group speech screen

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -555,15 +555,17 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
               continue;
             }
 
+            final isMe = name.trim().toLowerCase() ==
+                _myName.trim().toLowerCase();
             _messages.add({
               'user': name,
               'text': text,
               'time': time,
-              'isMe': false,
+              'isMe': isMe,
               'spoken': false,
               'audioLabel': label,
             });
-            _latestSentence = text;
+            _latestSentence = '$name: $text';
             _latestSentenceTimer?.cancel();
             _latestSentenceTimer = Timer(const Duration(seconds: 5), () {
               setState(() {
@@ -612,7 +614,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
         'spoken': false,
       });
       _textController.clear();
-      _latestSentence = msg;
+      _latestSentence = '$_myName: $msg';
       _latestSentenceTimer?.cancel();
       _latestSentenceTimer = Timer(const Duration(seconds: 5), () {
         setState(() {


### PR DESCRIPTION
## Summary
- mark recognized speaker as current user when the name matches
- show speaker name alongside the last transcribed sentence

## Testing
- `dart format lib/feature/auth/presentation/views/group_speach_text.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a40948699c8331af5982c2a80a4575