### PR TITLE
Add required model and language fields to ElevenLabs transcription request

### DIFF
--- a/lib/config/api_endpoints.dart
+++ b/lib/config/api_endpoints.dart
@@ -42,4 +42,6 @@ static const String _elevenLabsBaseUrl = 'https://api.elevenlabs.io/v1';
 static const String listElevenLabsVoices = "${_elevenLabsBaseUrl}/voices";
 static const String elevenLabsSpeechToText =
     "${_elevenLabsBaseUrl}/speech-to-text";
+static const String elevenLabsModelId = 'eleven_monolingual_v1';
+static const String elevenLabsLanguage = 'en';
 }

--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -433,6 +433,8 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
       Uri.parse(ApiConstants.elevenLabsSpeechToText),
     )
       ..headers['xi-api-key'] = ApiConstants.elevenLabsApiKey
+      ..fields['model_id'] = ApiConstants.elevenLabsModelId
+      ..fields['language'] = ApiConstants.elevenLabsLanguage
       ..files.add(
         await http.MultipartFile.fromPath(
           'file',


### PR DESCRIPTION
## Summary
- include model and language fields for ElevenLabs speech-to-text requests
- expose ElevenLabs model and language constants

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a416cf7a0c8331a900c1865b2d36be