### PR TITLE
Display user count for identified speakers

### DIFF
--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -516,12 +516,30 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                     : ListView.builder(
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.only(top: 12, left: 18, right: 18, bottom: 40),
-                  itemCount: _speakers.length,
+                  itemCount: _speakers.length + 1,
                   itemBuilder: (_, i) {
-                    final s = _speakers[i];
-                    final avatarColors = _avatarGradients[i % _avatarGradients.length];
+                    if (i == 0) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8.0),
+                        child: Center(
+                          child: Text(
+                            'Users in meeting: ${_speakers.length}',
+                            style: TextStyle(
+                              color: widget.isDarkMode
+                                  ? Colors.cyanAccent
+                                  : Colors.deepPurpleAccent,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18,
+                            ),
+                          ),
+                        ),
+                      );
+                    }
+                    final s = _speakers[i - 1];
+                    final avatarColors =
+                        _avatarGradients[(i - 1) % _avatarGradients.length];
                     final anim = Tween<Offset>(
-                        begin: Offset(0, 0.16 * (i + 1)), end: Offset.zero)
+                            begin: Offset(0, 0.16 * i), end: Offset.zero)
                         .animate(CurvedAnimation(
                       parent: _listAnimController,
                       curve: Interval(0.05 * i, 0.4 + 0.10 * i, curve: Curves.easeOut),
@@ -635,6 +653,16 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                                     spacing: 10,
                                     runSpacing: 6,
                                     children: [
+                                      Text(
+                                        'User $i',
+                                        style: TextStyle(
+                                          color: widget.isDarkMode
+                                              ? Colors.cyanAccent
+                                              : Colors.deepPurpleAccent,
+                                          fontWeight: FontWeight.w600,
+                                          fontSize: 16,
+                                        ),
+                                      ),
                                       Text(
                                         s.name,
                                         style: TextStyle(


### PR DESCRIPTION
## Summary
- show total speakers in meeting at top of list
- number each speaker entry as User N for quick recognition

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5756c0e548331bda581000e55617c