### PR TITLE
Show meeting user count in group chat

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -199,6 +199,15 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     }
   }
 
+  int get _usersInMeetingCount {
+    final users = <String>{_myName};
+    for (var m in _messages) {
+      final user = m['user'];
+      if (user is String) users.add(user);
+    }
+    return users.length;
+  }
+
   Future<void> _startListening() async {
     final available = await _speech.initialize();
     if (!available) return;
@@ -532,6 +541,17 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
               Column(
                 children: [
                   const SizedBox(height: 20),
+                  Text(
+                    'Users in meeting: $_usersInMeetingCount',
+                    style: TextStyle(
+                      color: widget.isDarkMode
+                          ? Colors.cyanAccent
+                          : Colors.deepPurpleAccent,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [

--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -516,33 +516,16 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                     : ListView.builder(
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.only(top: 12, left: 18, right: 18, bottom: 40),
-                  itemCount: _speakers.length + 1,
+                  itemCount: _speakers.length,
                   itemBuilder: (_, i) {
-                    if (i == 0) {
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 8.0),
-                        child: Center(
-                          child: Text(
-                            'Users in meeting: ${_speakers.length}',
-                            style: TextStyle(
-                              color: widget.isDarkMode
-                                  ? Colors.cyanAccent
-                                  : Colors.deepPurpleAccent,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 18,
-                            ),
-                          ),
-                        ),
-                      );
-                    }
-                    final s = _speakers[i - 1];
+                    final s = _speakers[i];
                     final avatarColors =
-                        _avatarGradients[(i - 1) % _avatarGradients.length];
+                        _avatarGradients[i % _avatarGradients.length];
                     final anim = Tween<Offset>(
-                            begin: Offset(0, 0.16 * i), end: Offset.zero)
+                            begin: Offset(0, 0.16 * (i + 1)), end: Offset.zero)
                         .animate(CurvedAnimation(
                       parent: _listAnimController,
-                      curve: Interval(0.05 * i, 0.4 + 0.10 * i, curve: Curves.easeOut),
+                      curve: Interval(0.05 * (i + 1), 0.4 + 0.10 * (i + 1), curve: Curves.easeOut),
                     ));
                     return SlideTransition(
                       position: anim,


### PR DESCRIPTION
## Summary
- remove meeting user count from speaker list
- display meeting participant count in group speech-to-text screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a579cfe9788331868afa99222a3805