### PR TITLE
Mask speaker names with generic identifiers

### DIFF
--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -612,9 +612,7 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                                     ),
                                     child: Center(
                                       child: Text(
-                                        s.name.isNotEmpty
-                                            ? s.name[0].toUpperCase()
-                                            : '?',
+                                        '${i + 1}',
                                         style: const TextStyle(
                                           color: Colors.white,
                                           fontWeight: FontWeight.bold,
@@ -637,23 +635,13 @@ class SpeakerScreenState extends State<SpeakerScreen> with TickerProviderStateMi
                                     runSpacing: 6,
                                     children: [
                                       Text(
-                                        'User $i',
+                                        'User ${i + 1}',
                                         style: TextStyle(
                                           color: widget.isDarkMode
                                               ? Colors.cyanAccent
                                               : Colors.deepPurpleAccent,
                                           fontWeight: FontWeight.w600,
                                           fontSize: 16,
-                                        ),
-                                      ),
-                                      Text(
-                                        s.name,
-                                        style: TextStyle(
-                                          color: widget.isDarkMode
-                                              ? Colors.white
-                                              : Colors.black87,
-                                          fontWeight: FontWeight.w700,
-                                          fontSize: 19,
                                         ),
                                       ),
                                       Container(


### PR DESCRIPTION
## Summary
- Display generic speaker labels (User 1, User 2, ...) instead of real names on identify speaker screen.

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c096c48833180cb89fd11bfb25e