### PR TITLE
feat: set speech locale to app language

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -232,8 +232,9 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     setState(() {
       _isRecording = true;
     });
-    final localeId =
-        _showTextMyLanguage ? _localeIdForLanguage(_appLanguageCode) : null;
+    // Always listen in the user's selected app language to support
+    // multilingual speech recognition.
+    final localeId = _localeIdForLanguage(_appLanguageCode);
     _speech.listen(
       onResult: _onSpeechResult,
       listenMode: ListenMode.dictation,


### PR DESCRIPTION
## Summary
- always use the selected app language when starting speech recognition

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58ffd7520833194fd2afab99febba