### PR TITLE
Avoid awaiting history save to speed up speech

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -282,7 +282,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     _latestSentenceTimer = Timer(const Duration(seconds: 5), () {
       setState(() => _latestSentence = '');
     });
-    await _saveCurrentMeetingToFirestore();
+    unawaited(_saveCurrentMeetingToFirestore());
     if (_speakOnMeeting) {
       await _speakMyLastMessage(text);
     }
@@ -327,9 +327,7 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
         });
       });
     });
-
-    await _saveCurrentMeetingToFirestore();
-    await Future.delayed(const Duration(milliseconds: 120));
+    unawaited(_saveCurrentMeetingToFirestore());
     if (_speakOnMeeting) {
       await _speakMyLastMessage(msg);
     }


### PR DESCRIPTION
## Summary
- avoid awaiting Firestore meeting saves so speech output is not delayed
- drop artificial delay before speaking new text

## Testing
- `dart format lib/feature/auth/presentation/views/group_speach_text.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59415735c83318015e2a7ec48a379