### PR TITLE
Avoid reloading speaker model by singleton service

### DIFF
--- a/lib/core/speaker/speaker_service.dart
+++ b/lib/core/speaker/speaker_service.dart
@@ -25,18 +25,29 @@ class _Wav {
 /// - Otherwise robust heuristic (RMS/ZCR + bands + VAD)
 /// Stores multiple samples per user; matches with cosine + margin.
 class SpeakerService {
-  static const _assetModelPath = 'assets/models/3dspeaker_speech_eres2netv2_sv_zh-cn_16k-common.onnx';
+  SpeakerService._internal();
+  static final SpeakerService _instance = SpeakerService._internal();
+
+  factory SpeakerService() => _instance;
+
+  static const _assetModelPath =
+      'assets/models/3dspeaker_speech_eres2netv2_sv_zh-cn_16k-common.onnx';
 
   SpeakerEmbeddingExtractor? _extractor; // non-null when ONNX model is available
-  String? _modelLocalPath;               // copied model path in app storage
+  String? _modelLocalPath; // copied model path in app storage
 
-  late String _storeKey;                 // per-mode bucket
+  late String _storeKey; // per-mode bucket
+
+  bool _initialized = false;
 
   bool get isReady => _extractor != null;
   bool get isFallback => _extractor == null;
 
   /// Initialize backend + decide per-mode storage key.
   Future<void> init() async {
+    if (_initialized) return;
+    _initialized = true;
+
     try {
       initBindings();
     } catch (_) {}
@@ -77,10 +88,12 @@ class SpeakerService {
   }
 
   Future<void> dispose() async {
+    if (!_initialized) return;
     try {
       _extractor?.free();
     } catch (_) {}
     _extractor = null;
+    _initialized = false;
   }
 
   // ---------------- Public API ----------------

--- a/lib/feature/auth/presentation/views/add_contact_screen.dart
+++ b/lib/feature/auth/presentation/views/add_contact_screen.dart
@@ -131,7 +131,6 @@ class _AddContactScreenState extends State<AddContactScreen>
     _ampTimer?.cancel();
     _maxRecordTimer?.cancel();
     _recorder.dispose();
-    _speakerService.dispose();
     _micPulse.dispose();
     _checkBurst.dispose();
     _nameController?.dispose();

--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -129,7 +129,6 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     _textController.dispose();
     _flutterTts.stop();
     _recorder.dispose();
-    _speakerService.dispose();
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/feature/auth/presentation/views/identify_speaker_screen.dart
+++ b/lib/feature/auth/presentation/views/identify_speaker_screen.dart
@@ -82,7 +82,6 @@ class _SpeakerScreenState extends State<SpeakerScreen> {
   @override
   void dispose() {
     _recorder.dispose();
-    _service.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- Implement SpeakerService as a singleton with one-time init and safe disposal
- Stop disposing SpeakerService in individual screens to reuse the global instance

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae935d2a188331ab088f28f640a28c