### PR TITLE
Log speaker match confidence for speech segments

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -594,6 +594,15 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
       });
     }
 
+    // Log the final identified speaker and confidence to the terminal so
+    // developers can easily see who was matched for each utterance.
+    final percent = (bestScore * 100).toStringAsFixed(1);
+    if (showName) {
+      print('Identified speaker: $detectedName at $percent%');
+    } else {
+      print('Identified speaker: Anonymous (below threshold)');
+    }
+
     // Persist
     unawaited(_saveCurrentMeetingToFirestore());
 


### PR DESCRIPTION
## Summary
- print identified speaker and match percentage in terminal for each finalized message

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aef9d410488331a70187d243547384