### PR TITLE
Handle speech timeout error as transient in speech screen

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -320,7 +320,9 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen>
     if (_isDisposed || !mounted) return;
 
     // For transient errors (e.g. timeout), don't stop the flow – just retry.
-    if (!error.permanent) {
+    // Some platforms report `error_speech_timeout` as permanent; treat it as transient
+    // so listening restarts automatically.
+    if (!error.permanent || error.errorMsg == 'error_speech_timeout') {
       setState(() => _amplitude = 0);
       Future.delayed(const Duration(milliseconds: 500), () {
         if (!_isDisposed && mounted && _isRecording && !_speech.isListening) {


### PR DESCRIPTION
## Summary
- Treat `error_speech_timeout` as a transient error and restart speech-to-text listening automatically

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aefb67dc948331bed3d3c33edcb7ab