### PR TITLE
fix: correct PCM16 encoding and log websocket events

### DIFF
--- a/lib/feature/auth/presentation/views/group_speach_text.dart
+++ b/lib/feature/auth/presentation/views/group_speach_text.dart
@@ -252,6 +252,21 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
     }
   }
 
+  /// Ensures outgoing audio chunks are little-endian PCM16.
+  /// Some platforms may provide PCM data in a different endianness, so we
+  /// explicitly rewrite each 16-bit sample from the host endianness to
+  /// little-endian before sending it to AssemblyAI.
+  Uint8List _toPCM16LE(Uint8List data) {
+    final out = Uint8List(data.length);
+    final input = ByteData.sublistView(data);
+    final output = ByteData.sublistView(out);
+    for (int i = 0; i < data.length ~/ 2; i++) {
+      final sample = input.getInt16(i * 2, Endian.host);
+      output.setInt16(i * 2, sample, Endian.little);
+    }
+    return out;
+  }
+
   // 🔧 FIXED: use /v3/ws (not just /v3). Kept sample_rate & encoding. Added format_turns and a keep-alive ping.
   Future<void> _initAssemblyConnection() async {
     try {
@@ -395,12 +410,24 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
             print("🔀 Turn detected for $spName: $text [$start-$end]");
             unawaited(
                 _sendTurnChunk(text: text, start: start, end: end, speaker: spName));
+          } else if (msgType == 'sessionbegins' ||
+              msgType == 'session_begins') {
+            print('🚀 Session begins');
+          } else if (msgType == 'sessionended' ||
+              msgType == 'session_ended') {
+            print('🏁 Session ended');
+          } else if (msgType == 'error') {
+            print('⚠️ Error from AssemblyAI: ${data['error'] ?? message}');
           } else {
             print("ℹ️ Other message type: $rawType");
           }
         } catch (e) {
           print("❌ Failed to parse: $e");
         }
+      }, onError: (error) {
+        print('⚠️ WebSocket error: $error');
+      }, onDone: () {
+        print('🔚 WebSocket connection closed');
       });
 
 
@@ -438,8 +465,10 @@ class _GroupSpeechToTextScreenState extends State<GroupSpeechToTextScreen> with 
 
     _audioStreamSub = stream.listen((data) {
       if (_assemblyChannel != null) {
-        final base64Chunk = base64Encode(data);
-        print("🎤 Sending ${data.length} bytes");
+        final pcmBytes = _toPCM16LE(data);
+        final base64Chunk = base64Encode(pcmBytes);
+        final hasAudio = pcmBytes.any((b) => b != 0);
+        print("🎤 Sending ${pcmBytes.length} bytes${hasAudio ? '' : ' (all zeros)'}");
         _assemblyChannel!.sink.add(jsonEncode({
           "audio_data": base64Chunk,
         }));


### PR DESCRIPTION
## Summary
- convert audio from host endianness to little-endian PCM16 before streaming
- expand AssemblyAI WebSocket logging to include session end and errors, and flag silent audio chunks

## Testing
- `dart format lib/feature/auth/presentation/views/group_speach_text.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c430d607f083319f333eaeb311e08c