### PR TITLE
Rename app branding to Hearing Access

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:label="Awa"
+        android:label="Hearing Access"
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
         android:allowBackup="false"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Awa</string>
+    <string name="app_name">Hearing Access</string>
     <string name="facebook_app_id">2881372545378324</string>
     <string name="facebook_client_token">873136798e17807af9296dc0851a91a2</string>
 </resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Awa</string>
+	<string>Hearing Access</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -748,7 +748,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
             SizedBox(width: 8),
             Expanded(
               child: Text(
-                "Subscription activated! Welcome to AWA Premium 🎉",
+                "Subscription activated! Welcome to Hearing Access Premium 🎉",
                 style: TextStyle(fontWeight: FontWeight.w600),
               ),
             ),
@@ -852,7 +852,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                   Icon(Icons.workspace_premium, color: Colors.amber, size: 48),
                   const SizedBox(height: 8),
                   Text(
-                    "AWA Premium Subscription",
+                    "Hearing Access Premium Subscription",
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 21,

--- a/lib/feature/auth/presentation/views/onboarding_screen.dart
+++ b/lib/feature/auth/presentation/views/onboarding_screen.dart
@@ -20,21 +20,21 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       title: "Text Every Spoken Word",
       subtitle: "Real-time speech-to-text for the deaf.",
       description:
-      "AWA instantly converts spoken conversations into clear, readable text—making it easy for deaf individuals to follow group discussions.",
+      "Hearing Access instantly converts spoken conversations into clear, readable text—making it easy for deaf individuals to follow group discussions.",
       imageAsset: "https://cdn-icons-png.flaticon.com/512/1082/1082435.png",
     ),
     _OnboardData(
       title: "Instant Voice to Text",
       subtitle: "Never miss what’s said.",
       description:
-      "AWA listens to every word and shows it as text immediately, helping the hearing impaired stay engaged in real time.",
+      "Hearing Access listens to every word and shows it as text immediately, helping the hearing impaired stay engaged in real time.",
       imageAsset: "https://cdn-icons-png.flaticon.com/512/2920/2920039.png",
     ),
     _OnboardData(
       title: "Inclusive Group Conversations",
       subtitle: "Empowering deaf communication.",
       description:
-      "Feel confident and connected. AWA ensures deaf and hard-of-hearing users are part of every conversation—clearly and equally.",
+      "Feel confident and connected. Hearing Access ensures deaf and hard-of-hearing users are part of every conversation—clearly and equally.",
       imageAsset: "https://cdn-icons-png.flaticon.com/512/3135/3135715.png",
     ),
   ];

--- a/lib/feature/auth/presentation/views/privacy_policy_screen.dart
+++ b/lib/feature/auth/presentation/views/privacy_policy_screen.dart
@@ -101,7 +101,7 @@ class PrivacyPolicyScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 6),
                   Text(
-                    'Welcome to AWA. Your privacy is critically important to us. This Policy explains how we collect, use, and protect your information.',
+                    'Welcome to Hearing Access. Your privacy is critically important to us. This Policy explains how we collect, use, and protect your information.',
                     style: TextStyle(color: subTextColor),
                   ),
                   const SizedBox(height: 16),
@@ -184,7 +184,7 @@ class PrivacyPolicyScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 6),
                   Text(
-                    'AWA is not directed to children under 13. We do not knowingly collect data from minors.',
+                    'Hearing Access is not directed to children under 13. We do not knowingly collect data from minors.',
                     style: TextStyle(color: subTextColor),
                   ),
                   const SizedBox(height: 16),
@@ -223,7 +223,7 @@ class PrivacyPolicyScreen extends StatelessWidget {
 
                   Center(
                     child: Text(
-                      'Thank you for trusting AWA with your privacy.',
+                      'Thank you for trusting Hearing Access with your privacy.',
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 16,

--- a/lib/feature/auth/presentation/views/terms_condition_screen.dart
+++ b/lib/feature/auth/presentation/views/terms_condition_screen.dart
@@ -94,7 +94,7 @@ class TermsAndConditionsScreen extends StatelessWidget {
                           fontSize: 18, fontWeight: FontWeight.bold, color: textColor)),
                   const SizedBox(height: 6),
                   Text(
-                    'By downloading or using AWA, you agree to be bound by these Terms & Conditions.',
+                    'By downloading or using Hearing Access, you agree to be bound by these Terms & Conditions.',
                     style: TextStyle(color: subTextColor),
                   ),
                   const SizedBox(height: 16),
@@ -114,7 +114,7 @@ class TermsAndConditionsScreen extends StatelessWidget {
                           fontSize: 18, fontWeight: FontWeight.bold, color: textColor)),
                   const SizedBox(height: 6),
                   Text(
-                    'AWA grants you a revocable, non-exclusive, non-transferable, limited license to download, install, and use the app solely for your personal, non-commercial purposes.',
+                    'Hearing Access grants you a revocable, non-exclusive, non-transferable, limited license to download, install, and use the app solely for your personal, non-commercial purposes.',
                     style: TextStyle(color: subTextColor),
                   ),
                   const SizedBox(height: 16),
@@ -144,7 +144,7 @@ class TermsAndConditionsScreen extends StatelessWidget {
                           fontSize: 18, fontWeight: FontWeight.bold, color: textColor)),
                   const SizedBox(height: 6),
                   Text(
-                    'In no event shall AWA be liable for any indirect, incidental, or consequential damages arising out of your use of the app.',
+                    'In no event shall Hearing Access be liable for any indirect, incidental, or consequential damages arising out of your use of the app.',
                     style: TextStyle(color: subTextColor),
                   ),
                   const SizedBox(height: 16),
@@ -171,7 +171,7 @@ class TermsAndConditionsScreen extends StatelessWidget {
 
                   Center(
                     child: Text(
-                      'Thank you for using AWA!',
+                      'Thank you for using Hearing Access!',
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 16,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -58,7 +58,7 @@
   "of_text":"of",
   "thisWillPermanently":"This will permanently delete your account and all data. Continue?",
   "goPremium":"Go Premium",
-  "awa":"AWA",
+  "awa":"Hearing Access",
   "premium":"Premium",
   "chatHistory":"Chat History",
   "groupChat":"Group Chat",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -458,7 +458,7 @@ abstract class AppLocalizations {
   /// No description provided for @awa.
   ///
   /// In en, this message translates to:
-  /// **'AWA'**
+  /// **'Hearing Access'**
   String get awa;
 
   /// No description provided for @premium.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -183,7 +183,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get goPremium => 'Go Premium';
 
   @override
-  String get awa => 'AWA';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'Premium';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -183,7 +183,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get goPremium => 'ਪ੍ਰੀਮੀਅਮ \'ਤੇ ਜਾਓ';
 
   @override
-  String get awa => 'AWA';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'ਪ੍ਰੀਮੀਅਮ';

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -58,7 +58,7 @@
   "of_text":"ਦੇ",
   "thisWillPermanently":"ਇਹ ਤੁਹਾਡੇ ਖਾਤੇ ਅਤੇ ਸਾਰੇ ਡੇਟਾ ਨੂੰ ਸਥਾਈ ਤੌਰ 'ਤੇ ਮਿਟਾ ਦੇਵੇਗਾ। ਕੀ ਜਾਰੀ ਰੱਖਣਾ ਹੈ?",
   "goPremium":"ਪ੍ਰੀਮੀਅਮ 'ਤੇ ਜਾਓ",
-  "awa":"AWA",
+  "awa":"Hearing Access",
   "premium":"ਪ੍ਰੀਮੀਅਮ",
   "chatHistory":"ਚੈਟ ਇਤਿਹਾਸ",
   "groupChat":"ਗਰੁੱਪ ਚੈਟ",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,7 +94,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return ShowCaseWidget(
       builder: (context) => MaterialApp.router(
-        title: 'Awa',
+        title: 'Hearing Access',
         debugShowCheckedModeBanner: false,
         theme: ThemeData(primarySwatch: Colors.blue),
         routerConfig: appRouter,


### PR DESCRIPTION
### Motivation
- Change the app name and visible branding from "AWA"/"Awa" to "Hearing Access" throughout the codebase to reflect the new product name.
- Ensure user-facing strings and localization entries show the updated name across platforms and locales.

### Description
- Replaced branding in the Flutter app title in `lib/main.dart` and updated Android app label in `android/app/src/main/AndroidManifest.xml` and resource `android/app/src/main/res/values/strings.xml`.
- Updated iOS display name in `ios/Runner/Info.plist` and replaced occurrences in UI copy including onboarding, privacy policy, terms & conditions, and home screen subscription texts.
- Updated localization resource files `lib/l10n/app_en.arb` and `lib/l10n/app_pa.arb` and the generated localization Dart files under `lib/l10n/` to reflect the new name.
- Applied a repository-wide replacement for occurrences of `AWA`/`Awa` to `Hearing Access` in the above files.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d051977148331a7d24b1f0b00e2a8)