### PR TITLE
Fix premium price parsing and update app name to Hearing Access

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>awa</string>
+	<string>Hearing Access</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/feature/auth/presentation/views/premium_intro_screen.dart
+++ b/lib/feature/auth/presentation/views/premium_intro_screen.dart
@@ -366,9 +366,12 @@ class _PremiumIntroScreenState extends State<PremiumIntroScreen>
       children: _plans.map((plan) {
         final isSelected = plan == _selectedPlan;
         final planLabel = plan['plan_name'] ?? 'Plan';
-        final price = plan['price'] != null
-            ? '₹${(plan['price'] as num).toStringAsFixed(0)}'
-            : '₹---';
+        final rawPrice = plan['price'];
+        final priceValue = rawPrice is num
+            ? rawPrice
+            : num.tryParse(rawPrice?.toString() ?? '');
+        final price =
+            priceValue != null ? '₹${priceValue.toStringAsFixed(0)}' : '₹---';
         final subtitle = plan['subtitle'] ?? (plan['duration_days'] != null
             ? "${plan['duration_days']} days"
             : null);

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -58,7 +58,7 @@
   "of_text": "এর",
   "thisWillPermanently": "এটি আপনার অ্যাকাউন্ট ও সব ডেটা স্থায়ীভাবে মুছে দেবে। চালিয়ে যাবেন?",
   "goPremium": "প্রিমিয়াম নিন",
-  "awa": "এডব্লিউএ",
+  "awa": "Hearing Access",
   "premium": "প্রিমিয়াম",
   "chatHistory": "চ্যাট ইতিহাস",
   "groupChat": "গ্রুপ চ্যাট",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -58,7 +58,7 @@
   "of_text": "માતે",
   "thisWillPermanently": "આ તમારા એકાઉન્ટ અને બધા ડેટા કાયમ માટે ડિલીટ કરશે. ચાલુ રાખશો?",
   "goPremium": "પ્રીમિયમ લો",
-  "awa": "એડબ્લ્યુએ",
+  "awa": "Hearing Access",
   "premium": "પ્રીમિયમ",
   "chatHistory": "ચેટ ઇતિહાસ",
   "groupChat": "ગ્રુપ ચેટ",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -58,7 +58,7 @@
   "of_text":"का",
   "thisWillPermanently":"इससे आपका खाता और सारा डेटा स्थायी रूप से मिट जाएगा। जारी रखें?",
   "goPremium":"प्रीमियम के लिए जाएँ",
-  "awa":"आवा",
+  "awa":"Hearing Access",
   "premium":"प्रीमियम",
   "chatHistory":"चैट का इतिहास",
   "groupChat":"समूह बातचीत",

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -183,7 +183,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get goPremium => 'প্রিমিয়াম নিন';
 
   @override
-  String get awa => 'এডব্লিউএ';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'প্রিমিয়াম';

--- a/lib/l10n/app_localizations_gu.dart
+++ b/lib/l10n/app_localizations_gu.dart
@@ -183,7 +183,7 @@ class AppLocalizationsGu extends AppLocalizations {
   String get goPremium => 'પ્રીમિયમ લો';
 
   @override
-  String get awa => 'એડબ્લ્યુએ';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'પ્રીમિયમ';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -183,7 +183,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get goPremium => 'प्रीमियम के लिए जाएँ';
 
   @override
-  String get awa => 'आवा';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'प्रीमियम';

--- a/lib/l10n/app_localizations_mr.dart
+++ b/lib/l10n/app_localizations_mr.dart
@@ -183,7 +183,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get goPremium => 'प्रीमियम घ्या';
 
   @override
-  String get awa => 'एडब्ल्यूए';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'प्रीमियम';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -183,7 +183,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get goPremium => 'பிரீமியம் பெறவும்';
 
   @override
-  String get awa => 'ஏடபிள்யூஏ';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'பிரீமியம்';

--- a/lib/l10n/app_localizations_ur.dart
+++ b/lib/l10n/app_localizations_ur.dart
@@ -183,7 +183,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get goPremium => 'پریمیم حاصل کریں';
 
   @override
-  String get awa => 'اے ڈبلیو اے';
+  String get awa => 'Hearing Access';
 
   @override
   String get premium => 'پریمیم';

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -58,7 +58,7 @@
   "of_text": "चा",
   "thisWillPermanently": "हे तुमचे खाते आणि सर्व डेटा कायमचे हटवेल. पुढे जाल का?",
   "goPremium": "प्रीमियम घ्या",
-  "awa": "एडब्ल्यूए",
+  "awa": "Hearing Access",
   "premium": "प्रीमियम",
   "chatHistory": "चॅट इतिहास",
   "groupChat": "ग्रुप चॅट",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -58,7 +58,7 @@
   "of_text": "இல்",
   "thisWillPermanently": "இது உங்கள் கணக்கையும் அனைத்து தரவையும் நிரந்தரமாக நீக்கும். தொடரவா?",
   "goPremium": "பிரீமியம் பெறவும்",
-  "awa": "ஏடபிள்யூஏ",
+  "awa": "Hearing Access",
   "premium": "பிரீமியம்",
   "chatHistory": "அரட்டை வரலாறு",
   "groupChat": "குழு அரட்டை",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -58,7 +58,7 @@
   "of_text": "کا",
   "thisWillPermanently": "یہ آپ کا اکاؤنٹ اور تمام ڈیٹا مستقل طور پر حذف کر دے گا۔ کیا جاری رکھیں؟",
   "goPremium": "پریمیم حاصل کریں",
-  "awa": "اے ڈبلیو اے",
+  "awa": "Hearing Access",
   "premium": "پریمیم",
   "chatHistory": "چیٹ ہسٹری",
   "groupChat": "گروپ چیٹ",

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="awa">
+  <meta name="apple-mobile-web-app-title" content="Hearing Access">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>awa</title>
+  <title>Hearing Access</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "awa",
-    "short_name": "awa",
+    "name": "Hearing Access",
+    "short_name": "Hearing Access",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash when premium plan `price` is not a numeric type by making parsing resilient to strings or nulls.
- Standardize the app display name from `awa` to `Hearing Access` across web, iOS metadata and localizations.
- Ensure the premium plans UI shows a stable placeholder (`₹---`) when price cannot be parsed.
- Keep localization keys intact while updating the displayed app name in `.arb` and generated localization Dart files.

### Description
- Guarded price formatting in `lib/feature/auth/presentation/views/premium_intro_screen.dart` by checking `rawPrice` type and using `num.tryParse` before calling `toStringAsFixed`.
- Replaced app title strings in `web/index.html` and `web/manifest.json` to `Hearing Access` and updated `ios/Runner/Info.plist` `CFBundleName` to `Hearing Access`.
- Updated multiple localization files (`lib/l10n/app_*.arb` and generated `app_localizations_*.dart`) to map the `awa` key to `Hearing Access` for supported locales.
- Minor formatting tweak to the `price` assignment expression to improve line-wrapping.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0d65b1008331938dc911af7a44f1)