### PR TITLE
Fix home app bar overflow and show Hearing Access on splash

### DIFF
--- a/lib/feature/auth/presentation/views/home_screen.dart
+++ b/lib/feature/auth/presentation/views/home_screen.dart
@@ -1361,129 +1361,148 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                           tooltip: 'Menu',
                         ),
                       ),
-                      title: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.all(6),
-                            decoration: BoxDecoration(
-                              color: _isDarkMode
-                                  ? Colors.cyanAccent.withOpacity(0.13)
-                                  : Colors.white.withOpacity(0.19),
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: _isDarkMode
-                                      ? Colors.cyanAccent.withOpacity(0.23)
-                                      : Colors.blueAccent.withOpacity(0.16),
-                                  blurRadius: 20,
-                                  spreadRadius: 3,
-                                  offset: Offset(0, 6),
-                                ),
-                              ],
-                            ),
-                            child: Image.asset(
-                              'assets/images/awa_logo.webp',
-                              height: 32,
-                              width: 32,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          ShaderMask(
-                            shaderCallback: (bounds) => LinearGradient(
-                              colors: _isDarkMode
-                                  ? [
-                                Colors.cyanAccent,
-                                Colors.blueAccent,
-                                Colors.white,
-                              ]
-                                  : [
-                                Colors.deepPurple,
-                                Colors.indigo,
-                                Colors.amber,
-                              ],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            ).createShader(bounds),
-                            child: Text(
-                              context.loc.awa,
-                              style: TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.w900,
-                                color: Colors.white,
-                                letterSpacing: 1.6,
-                                shadows: [
-                                  Shadow(
-                                    color: Colors.black.withOpacity(0.15),
-                                    blurRadius: 2,
-                                    offset: Offset(1, 1),
+                      title: LayoutBuilder(
+                        builder: (context, constraints) {
+                          return SizedBox(
+                            width: constraints.maxWidth,
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Container(
+                                  padding: const EdgeInsets.all(6),
+                                  decoration: BoxDecoration(
+                                    color: _isDarkMode
+                                        ? Colors.cyanAccent.withOpacity(0.13)
+                                        : Colors.white.withOpacity(0.19),
+                                    shape: BoxShape.circle,
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: _isDarkMode
+                                            ? Colors.cyanAccent.withOpacity(0.23)
+                                            : Colors.blueAccent.withOpacity(0.16),
+                                        blurRadius: 20,
+                                        spreadRadius: 3,
+                                        offset: Offset(0, 6),
+                                      ),
+                                    ],
                                   ),
-                                ],
-                              ),
-                            ),
-                          ),
-                          if (_isSubscribed || _trialSkip) ...[
-                            const SizedBox(width: 8),
-                            AnimatedContainer(
-                              duration: Duration(milliseconds: 900),
-                              padding: EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 3),
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  colors: [
-                                    Colors.amber.shade700,
-                                    Colors.amberAccent.shade200,
-                                    Colors.amber.shade400,
-                                  ],
-                                  begin: Alignment.topLeft,
-                                  end: Alignment.bottomRight,
-                                ),
-                                borderRadius: BorderRadius.circular(14),
-                                boxShadow: [
-                                  BoxShadow(
-                                    color: Colors.amber.withOpacity(0.21),
-                                    blurRadius: 14,
-                                    spreadRadius: 2,
+                                  child: Image.asset(
+                                    'assets/images/awa_logo.webp',
+                                    height: 32,
+                                    width: 32,
                                   ),
-                                ],
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(Icons.workspace_premium,
-                                      color: Colors.white, size: 12),
-                                  const SizedBox(width: 2),
-                                  ShaderMask(
-                                    shaderCallback: (bounds) => LinearGradient(
-                                      colors: [
-                                        Colors.white,
-                                        Colors.amberAccent,
-                                      ],
-                                      begin: Alignment.topLeft,
-                                      end: Alignment.bottomRight,
-                                    ).createShader(bounds),
-                                    child: Text(
-                                      context.loc.premium,
-                                      style: TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 11,
-                                        fontWeight: FontWeight.bold,
-                                        letterSpacing: 1.1,
-                                        shadows: [
-                                          Shadow(
-                                            color: Colors.amberAccent
-                                                .withOpacity(0.36),
-                                            blurRadius: 5,
-                                            offset: Offset(1, 1),
-                                          ),
+                                ),
+                                const SizedBox(width: 8),
+                                Flexible(
+                                  child: FittedBox(
+                                    fit: BoxFit.scaleDown,
+                                    child: ShaderMask(
+                                      shaderCallback: (bounds) => LinearGradient(
+                                        colors: _isDarkMode
+                                            ? [
+                                          Colors.cyanAccent,
+                                          Colors.blueAccent,
+                                          Colors.white,
+                                        ]
+                                            : [
+                                          Colors.deepPurple,
+                                          Colors.indigo,
+                                          Colors.amber,
                                         ],
+                                        begin: Alignment.topLeft,
+                                        end: Alignment.bottomRight,
+                                      ).createShader(bounds),
+                                      child: Text(
+                                        context.loc.awa,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w900,
+                                          color: Colors.white,
+                                          letterSpacing: 1.6,
+                                          shadows: [
+                                            Shadow(
+                                              color: Colors.black.withOpacity(0.15),
+                                              blurRadius: 2,
+                                              offset: Offset(1, 1),
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ],
-                              ),
+                                ),
+                                if (_isSubscribed || _trialSkip) ...[
+                                  const SizedBox(width: 8),
+                                  Flexible(
+                                    child: FittedBox(
+                                      fit: BoxFit.scaleDown,
+                                      child: AnimatedContainer(
+                                        duration: Duration(milliseconds: 900),
+                                        padding: EdgeInsets.symmetric(
+                                            horizontal: 8, vertical: 3),
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: [
+                                              Colors.amber.shade700,
+                                              Colors.amberAccent.shade200,
+                                              Colors.amber.shade400,
+                                            ],
+                                            begin: Alignment.topLeft,
+                                            end: Alignment.bottomRight,
+                                          ),
+                                          borderRadius: BorderRadius.circular(14),
+                                          boxShadow: [
+                                            BoxShadow(
+                                              color: Colors.amber.withOpacity(0.21),
+                                              blurRadius: 14,
+                                              spreadRadius: 2,
+                                            ),
+                                          ],
+                                        ),
+                                        child: Row(
+                                          children: [
+                                            Icon(Icons.workspace_premium,
+                                                color: Colors.white, size: 12),
+                                            const SizedBox(width: 2),
+                                            ShaderMask(
+                                              shaderCallback: (bounds) => LinearGradient(
+                                                colors: [
+                                                  Colors.white,
+                                                  Colors.amberAccent,
+                                                ],
+                                                begin: Alignment.topLeft,
+                                                end: Alignment.bottomRight,
+                                              ).createShader(bounds),
+                                              child: Text(
+                                                context.loc.premium,
+                                                style: TextStyle(
+                                                  color: Colors.white,
+                                                  fontSize: 11,
+                                                  fontWeight: FontWeight.bold,
+                                                  letterSpacing: 1.1,
+                                                  shadows: [
+                                                    Shadow(
+                                                      color: Colors.amberAccent
+                                                          .withOpacity(0.36),
+                                                      blurRadius: 5,
+                                                      offset: Offset(1, 1),
+                                                    ),
+                                                  ],
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ]
+                              ],
                             ),
-                          ]
-                        ],
+                          );
+                        },
                       ),
                       actions: [
                         Padding(

--- a/lib/feature/auth/presentation/views/splash_view.dart
+++ b/lib/feature/auth/presentation/views/splash_view.dart
@@ -19,10 +19,8 @@ class _SplashViewState extends State<SplashView>
   late final AnimationController _lettersController;
   late final Animation<double> _letter1Scale;
   late final Animation<double> _letter2Scale;
-  late final Animation<double> _letter3Scale;
   late final Animation<double> _letter1Opacity;
   late final Animation<double> _letter2Opacity;
-  late final Animation<double> _letter3Opacity;
 
   @override
   void initState() {
@@ -55,13 +53,6 @@ class _SplashViewState extends State<SplashView>
         curve: const Interval(0.2, 0.6, curve: Curves.elasticOut),
       ),
     );
-    _letter3Scale = Tween<double>(begin: 0, end: 1).animate(
-      CurvedAnimation(
-        parent: _lettersController,
-        curve: const Interval(0.4, 0.8, curve: Curves.elasticOut),
-      ),
-    );
-
     _letter1Opacity = Tween<double>(begin: 0, end: 1).animate(
       CurvedAnimation(
         parent: _lettersController,
@@ -72,12 +63,6 @@ class _SplashViewState extends State<SplashView>
       CurvedAnimation(
         parent: _lettersController,
         curve: const Interval(0.2, 0.6),
-      ),
-    );
-    _letter3Opacity = Tween<double>(begin: 0, end: 1).animate(
-      CurvedAnimation(
-        parent: _lettersController,
-        curve: const Interval(0.4, 0.8),
       ),
     );
 
@@ -117,9 +102,9 @@ class _SplashViewState extends State<SplashView>
     final size = MediaQuery.of(context).size;
     const textStyle = TextStyle(
       color: Colors.white,
-      fontSize: 48,
+      fontSize: 44,
       fontWeight: FontWeight.bold,
-      letterSpacing: 4,
+      letterSpacing: 2,
     );
 
     return Scaffold(
@@ -173,30 +158,22 @@ class _SplashViewState extends State<SplashView>
                 );
               },
             ),
-            Row(
+            Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 ScaleTransition(
                   scale: _letter1Scale,
                   child: FadeTransition(
                     opacity: _letter1Opacity,
-                    child: const Text('A', style: textStyle),
+                    child: const Text('Hearing', style: textStyle),
                   ),
                 ),
-                const SizedBox(width: 8),
+                const SizedBox(height: 6),
                 ScaleTransition(
                   scale: _letter2Scale,
                   child: FadeTransition(
                     opacity: _letter2Opacity,
-                    child: const Text('W', style: textStyle),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                ScaleTransition(
-                  scale: _letter3Scale,
-                  child: FadeTransition(
-                    opacity: _letter3Opacity,
-                    child: const Text('A', style: textStyle),
+                    child: const Text('Access', style: textStyle),
                   ),
                 ),
               ],


### PR DESCRIPTION
### Motivation
- Prevent a RenderFlex overflow in the home screen app bar by making the title area responsive.
- Reflect the app name change to "Hearing Access" on the splash screen.

### Description
- Replaced the app bar `title` Row with a `LayoutBuilder` + centered `Row` and constrained `SizedBox` to use available width.
- Wrapped the app name and premium badge in `Flexible` + `FittedBox` and set `maxLines`/`overflow` to avoid horizontal overflow.
- Updated `SplashView` animation to display the two-line text "Hearing" / "Access", removed the third-letter animations, and reduced the splash font sizing/letter spacing to better fit.
- Minor animation/controller cleanup to remove unused `_letter3Scale` and `_letter3Opacity` fields.

### Testing
- No automated tests were executed for this change.
- Manual runtime verification was not performed as part of the automated rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0ec0b160833189f94bdd80116605)